### PR TITLE
Linear regression examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ ZebrafishExampleVid.avi - provided by Nicholas Guilbeault in the Thiele lab at t
 
 ForagingMouseExampleVid.avi - provided by the Sainsbury Wellcome Centre Foraging Behaviour Working Group. (2023). Aeon: An open-source platform to study the neural basis of ethological behaviours over naturalistic timescales, [https://doi.org/10.5281/zenodo.8413142](https://doi.org/10.5281/zenodo.8413142)
 
+ReceptiveFieldSimpleCell.zip - provided by the authors of "Touryan, J., Felsen, G., & Dan, Y. (2005). Spatial structure of complex cell receptive fields measured with natural images. Neuron, 45(5), 781-791." [https://doi.org/10.1016/j.neuron.2005.01.029](https://doi.org/10.1016/j.neuron.2005.01.029)
+
 ### Acknowledgements
 
 Development of this package was supported by funding from the Biotechnology and Biological Sciences Research Council [grant number BB/W019132/1].

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -10,3 +10,8 @@
   href: ../examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/README.md
 - name: Foraging Mouse
   href: ../examples/LinearDynamicalSystems/Kinematics/ForagingMouse/README.md
+- name: Linear Regression
+- name: Simulated Data
+  href: ../examples/LinearDynamicalSystems/Kinematics/SimulatedData/README.md
+- name: Receptive Field Simple Cell
+  href: ../examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/README.md

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Packages>
+    <Package id="Bonsai" version="2.8.2"/>
+    <Package id="Bonsai.Core" version="2.8.1"/>
+    <Package id="Bonsai.Design" version="2.8.0"/>
+    <Package id="Bonsai.Editor" version="2.8.1"/>
+    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.1.1-build240320-01"/>
+    <Package id="Bonsai.ML.Visualizers" version="0.1.1-build240320-01"/>
+    <Package id="Bonsai.Scripting.Python" version="0.2.1"/>
+    <Package id="Bonsai.System" version="2.8.1"/>
+    <Package id="jacobslusser.ScintillaNET" version="3.6.3"/>
+    <Package id="Markdig" version="0.18.1"/>
+    <Package id="Microsoft.CSharp" version="4.7.0"/>
+    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
+    <Package id="Newtonsoft.Json" version="13.0.3"/>
+    <Package id="OxyPlot.Core" version="2.1.2"/>
+    <Package id="OxyPlot.WindowsForms" version="2.1.2"/>
+    <Package id="pythonnet" version="3.0.3"/>
+    <Package id="Rx-Core" version="2.2.5"/>
+    <Package id="Rx-Interfaces" version="2.2.5"/>
+    <Package id="Rx-Linq" version="2.2.5"/>
+    <Package id="Rx-PlatformServices" version="2.2.5"/>
+    <Package id="SvgNet" version="3.3.3"/>
+    <Package id="System.Reflection.Emit" version="4.3.0"/>
+    <Package id="YamlDotNet" version="13.1.1"/>
+  </Packages>
+  <AssemblyReferences>
+    <AssemblyReference assemblyName="Bonsai"/>
+    <AssemblyReference assemblyName="Bonsai.Core"/>
+    <AssemblyReference assemblyName="Bonsai.Design"/>
+    <AssemblyReference assemblyName="Bonsai.Editor"/>
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems"/>
+    <AssemblyReference assemblyName="Bonsai.ML.Visualizers"/>
+    <AssemblyReference assemblyName="Bonsai.Scripting.Python"/>
+    <AssemblyReference assemblyName="Bonsai.System"/>
+  </AssemblyReferences>
+  <AssemblyLocations>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.2\lib\net48\Bonsai.exe"/>
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.1\lib\net472\Bonsai.Editor.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.0.1.1-build240320-01\lib\net472\Bonsai.ML.LinearDynamicalSystems.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.ML.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Visualizers.0.1.1-build240320-01\lib\net472\Bonsai.ML.Visualizers.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Python.0.2.1\lib\net472\Bonsai.Scripting.Python.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll"/>
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll"/>
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll"/>
+    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages\OxyPlot.Core.2.1.2\lib\net45\OxyPlot.dll"/>
+    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages\OxyPlot.WindowsForms.2.1.2\lib\net45\OxyPlot.WindowsForms.dll"/>
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages\pythonnet.3.0.3\lib\netstandard2.0\Python.Runtime.dll"/>
+    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll"/>
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll"/>
+    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll"/>
+    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll"/>
+    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll"/>
+    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll"/>
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.1.1\lib\net47\YamlDotNet.dll"/>
+  </AssemblyLocations>
+  <LibraryFolders>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native" platform="arm64"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native_uap" platform="arm64"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native" platform="x64"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native_uap" platform="x64"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native" platform="x86"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86"/>
+  </LibraryFolders>
+</PackageConfiguration>

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/NuGet.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Gallery" value="Gallery" />
+    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
+    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Setup.ps1
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Setup.ps1
@@ -1,0 +1,19 @@
+if (!(Test-Path "./Bonsai.exe")) {
+    $release = "https://github.com/bonsai-rx/bonsai/releases/latest/download/Bonsai.zip"
+    $configPath = "./Bonsai.config"
+    if (Test-Path $configPath) {
+        [xml]$config = Get-Content $configPath
+        $bootstrapper = $config.PackageConfiguration.Packages.Package.where{$_.id -eq 'Bonsai'}
+        if ($bootstrapper) {
+            $version = $bootstrapper.version
+            $release = "https://github.com/bonsai-rx/bonsai/releases/download/$version/Bonsai.zip"
+        }
+    }
+    Invoke-WebRequest $release -OutFile "temp.zip"
+    Move-Item -Path "NuGet.config" "temp.config"
+    Expand-Archive "temp.zip" -DestinationPath "." -Force
+    Move-Item -Path "temp.config" "NuGet.config" -Force
+    Remove-Item -Path "temp.zip"
+	Remove-Item -Path "Bonsai32.exe"
+}
+& .\Bonsai.exe --no-editor

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Setup.sh
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Setup.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+CURRENT_DIR="$(pwd)"
+SETUP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd $SETUP_SCRIPT_DIR
+
+if [ ! -f "./Bonsai.exe" ]; then
+    CONFIG="./Bonsai.config"
+    if [ -f "$CONFIG" ]; then
+        VERSION=$(xmllint --xpath '//PackageConfiguration/Packages/Package[@id="Bonsai"]/@version' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+        RELEASE="https://github.com/bonsai-rx/bonsai/releases/download/$VERSION/Bonsai.zip"
+    else
+        RELEASE="https://github.com/bonsai-rx/bonsai/releases/latest/download/Bonsai.zip"
+    fi
+    wget $RELEASE -O "temp.zip"
+    mv -f "NuGet.config" "temp.config"
+    unzip -d "." -o "temp.zip"
+    mv -f "temp.config" "NuGet.config"
+    rm -rf "temp.zip"
+    rm -rf "Bonsai32.exe"
+fi
+
+source ./activate
+source ./run --no-editor
+cd $CURRENT_DIR

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/activate
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/activate
@@ -1,0 +1,14 @@
+#!/bin/bash
+# activate.sh
+if [[ -v BONSAI_EXE_PATH ]]; then
+    echo "Error! Cannot have multiple bonsai environments activated at the same time. Please deactivate the current environment before activating the new one."
+    return
+fi
+BONSAI_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+export BONSAI_EXE_PATH="$BONSAI_ENV_DIR/Bonsai.exe"
+export ORIGINAL_PS1="$PS1"
+export PS1="($(basename "$BONSAI_ENV_DIR")) $PS1"
+alias bonsai='source "$BONSAI_ENV_DIR"/run'
+alias bonsai-clean='GTK_DATA_PREFIX= source "$BONSAI_ENV_DIR"/run'
+alias deactivate='source "$BONSAI_ENV_DIR"/deactivate'
+echo "Activated bonsai environment in $BONSAI_ENV_DIR"

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/deactivate
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/deactivate
@@ -1,0 +1,8 @@
+#!/bin/bash
+unset BONSAI_EXE_PATH
+export PS1="$ORIGINAL_PS1"
+unset ORIGINAL_PS1
+unalias bonsai
+unalias bonsai-clean
+unalias deactivate
+echo "Deactivated bonsai environment."

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/run
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/run
@@ -1,0 +1,47 @@
+#!/bin/bash
+# run.sh
+
+CURRENT_DIR="$(pwd)"
+SETUP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd $SETUP_SCRIPT_DIR
+
+CONFIG="./Bonsai.config"
+BACKUP_CONFIG="${CONFIG}.backup"
+
+cleanup() {
+    update_paths_to_windows
+    cd $CURRENT_DIR
+}
+
+update_paths_to_linux() {
+    ASSEMBLYLOCATIONS=$(xmllint --xpath '//PackageConfiguration/AssemblyLocations/AssemblyLocation/@location' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+    for ASSEMBLYLOCATION in $ASSEMBLYLOCATIONS; do
+        NEWASSEMBLYLOCATION="${ASSEMBLYLOCATION//\\/\/}"
+        xmlstarlet edit --inplace --update "/PackageConfiguration/AssemblyLocations/AssemblyLocation[@location='$ASSEMBLYLOCATION']/@location" --value "$NEWASSEMBLYLOCATION" "$CONFIG"
+    done
+
+    LIBRARYFOLDERS=$(xmllint --xpath '//PackageConfiguration/LibraryFolders/LibraryFolder/@path' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+    for LIBRARYFOLDER in $LIBRARYFOLDERS; do
+        NEWLIBRARYFOLDER="${LIBRARYFOLDER//\\/\/}"
+        xmlstarlet edit --inplace --update "//PackageConfiguration/LibraryFolders/LibraryFolder[@path='$LIBRARYFOLDER']/@path" --value "$NEWLIBRARYFOLDER" "$CONFIG"
+    done
+}
+
+update_paths_to_windows() {
+    ASSEMBLYLOCATIONS=$(xmllint --xpath '//PackageConfiguration/AssemblyLocations/AssemblyLocation/@location' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+    for ASSEMBLYLOCATION in $ASSEMBLYLOCATIONS; do
+        NEWASSEMBLYLOCATION="${ASSEMBLYLOCATION//\//\\}"
+        xmlstarlet edit --inplace --update "/PackageConfiguration/AssemblyLocations/AssemblyLocation[@location='$ASSEMBLYLOCATION']/@location" --value "$NEWASSEMBLYLOCATION" "$CONFIG"
+    done
+
+    LIBRARYFOLDERS=$(xmllint --xpath '//PackageConfiguration/LibraryFolders/LibraryFolder/@path' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+    for LIBRARYFOLDER in $LIBRARYFOLDERS; do
+        NEWLIBRARYFOLDER="${LIBRARYFOLDER//\//\\}"
+        xmlstarlet edit --inplace --update "//PackageConfiguration/LibraryFolders/LibraryFolder[@path='$LIBRARYFOLDER']/@path" --value "$NEWLIBRARYFOLDER" "$CONFIG"
+    done
+}
+
+trap cleanup EXIT INT TERM
+update_paths_to_linux
+mono "$BONSAI_EXE_PATH" "$@"
+cleanup

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/README.md
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/README.md
@@ -1,0 +1,39 @@
+# Receptive Field Simple Cell
+
+The code for this repo can be found [here](https://github.com/bonsai-rx/machinelearning-examples/tree/main/examples/LinearDynamicalSystems/BayesianLinearRegression/ReceptiveFieldSimpleCell).
+
+In the following example, you can find how the Kalman Filter can be used to estimate the linear receptive field of a simple cell recorded from an anesthitized cat.
+
+### Dependencies
+
+If you used the bootstrapping method, you dont have to worry about the package dependencies, as these should be already installed. However, if creating a new environment or integrating into an existing one, you will need to install the following packages:
+
+* Bonsai - System v2.8.1
+* Bonsai - ML LinearDynamicalSystems v0.1.0
+* Bonsai - ML Visualizers v0.1.0
+
+### Dataset
+
+The data for this example was generously provided by the authors of "Touryan, J., Felsen, G., & Dan, Y. (2005). Spatial structure of complex cell receptive fields measured with natural images. Neuron, 45(5), 781-791."
+
+You can download the `ReceptiveFieldSimpleCell.zip` dataset here: [https://doi.org/10.5281/zenodo.10629221](https://doi.org/10.5281/zenodo.10629221). It consists of 2 csv files: one which contains the all 144 pixel values of the 12 x 12 images for each timepoint, and one which contains the binned spike counts for a single neuron. Once downloaded, you will need to extract the contents of the zip file into the `datasets` folder.
+
+### Workflow
+
+Below is the example workflow for how to perform online estimation of the receptive field of a simple visual neuron. In the workflow, we use previously acquired data and read the values sequentially, but this workflow can easily be adapted to real-time stimulus presentation and online neural recording.
+
+:::workflow
+![Linear Regression - Receptive Field Simple Cell](ReceptiveFieldSimpleCell.bonsai)
+:::
+
+In this example, a Kalman Filter is used to estimate the receptive field using Bayesian inference. It receives the pixel values, represented by a flattened array of the 2D visual stimulus, and infers the response of the neuron. In the `images.csv` file, there are 144 columns. These columns represent the pixel values of the stimulus that was displayed (a 12 x 12 image for a total of 144 pixels). The neuron's binned spike count is recorded in response to each image. These responses are recorded in the `responses.csv` file. In the `LoadData` group node, we read in the values from each csv file and zip them together. We add an additional feature to the image observations to represent our model's intercept. This is done when we convert the images csv data to a list in the `Format` node inside the `LoadData` group node. Since we are loading all of our data at once, we store the data inside of a `ReplaySubject` which will represent our `observation` of data.
+
+In the `CreateKFModel` node, we specify the number of features that will be used observed at each time step. This number is set to the total number of pixels in our image (144 total) plus an additional feature that is used to represent the model intercept. We then specify the coefficients for our precision of the likelihood and the prior. 
+
+We wait for the model to initialize and then subscribe to the data observations using the `SubscribeWhen` node. As the workflow runs, the model will perform bayesian inference to learn the visual features that the neuron responds strongly too. The neurons receptive field can then be visualized as the models state parameters evolving through time.
+
+To visualize the neurons receptive field, double click on the `ReceptiveFieldSimpleCell` node at the bottom of the workflow while it is running. You should see a heatmap visualization of the receptive field. You can interact with this heatmap by left clicking to read the values at each pixel, right click to pan the image, or use the scroll wheel to zoom in/out. When you right click, you will see several options appear at the bottom of the visualizer's window where you can change the color palette and render method online. You can reset the plot to the original view by holding `Ctrl` and double right-click.
+
+The window should look like this:
+
+![Receptive Field Simple Cell](ReceptiveFieldSimpleCell.gif)

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/ReceptiveFieldSimpleCell.bonsai
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/ReceptiveFieldSimpleCell.bonsai
@@ -1,0 +1,133 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
+                 xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:Bonsai.ML.LinearDynamicalSystems;assembly=Bonsai.ML.LinearDynamicalSystems"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:CreateRuntime" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:GetRuntime" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="GroupWorkflow">
+        <Name>LoadData</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="FileName" DisplayName="ImagesCsv" Category="PathToDataset" />
+            </Expression>
+            <Expression xsi:type="io:CsvReader">
+              <io:FileName>../../../../datasets/ReceptiveFieldSimpleCell/images.csv</io:FileName>
+              <io:ListSeparator />
+              <io:ScanPattern />
+              <io:SkipRows>1</io:SkipRows>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="FileName" DisplayName="ResponsesCsv" Category="PathToDataset" />
+            </Expression>
+            <Expression xsi:type="io:CsvReader">
+              <io:FileName>../../../../datasets/ReceptiveFieldSimpleCell/responses.csv</io:FileName>
+              <io:ListSeparator />
+              <io:ScanPattern>%d</io:ScanPattern>
+              <io:SkipRows>1</io:SkipRows>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Zip" />
+            </Expression>
+            <Expression xsi:type="Format">
+              <Format>x=[{0},1],y={1}</Format>
+              <Selector>it.Item1,it.Item2</Selector>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="4" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+            <Edge From="3" To="4" Label="Source2" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="5" To="6" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="rx:ReplaySubject">
+        <Name>Observation</Name>
+        <rx:BufferSize xsi:nil="true" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:GetRuntime" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.CreateKFModel.bonsai">
+        <LikelihoodPrecisionCoef>0.1</LikelihoodPrecisionCoef>
+        <PriorPrecisionCoef>2</PriorPrecisionCoef>
+        <N_features>145</N_features>
+        <Name>model</Name>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>ModelParameters</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Observation</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>ModelParameters</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:SubscribeWhen" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.PerformInference.bonsai">
+        <Name>model</Name>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>ReceptiveFieldSimpleCell</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>X</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p1:Slice">
+                <p1:RowStart xsi:nil="true" />
+                <p1:RowEnd>144</p1:RowEnd>
+                <p1:ColStart xsi:nil="true" />
+                <p1:ColEnd xsi:nil="true" />
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p1:Reshape">
+                <p1:Rows>12</p1:Rows>
+                <p1:Cols>12</p1:Cols>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="8" To="10" Label="Source1" />
+      <Edge From="9" To="10" Label="Source2" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="12" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Packages>
+    <Package id="Bonsai" version="2.8.2"/>
+    <Package id="Bonsai.Core" version="2.8.1"/>
+    <Package id="Bonsai.Design" version="2.8.0"/>
+    <Package id="Bonsai.Design.Visualizers" version="2.8.0"/>
+    <Package id="Bonsai.Editor" version="2.8.1"/>
+    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.1.1-build240320-01"/>
+    <Package id="Bonsai.ML.Visualizers" version="0.1.1-build240320-01"/>
+    <Package id="Bonsai.Numerics" version="0.9.0"/>
+    <Package id="Bonsai.Scripting" version="2.8.0"/>
+    <Package id="Bonsai.Scripting.Expressions" version="2.8.0"/>
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0"/>
+    <Package id="Bonsai.Scripting.IronPython" version="2.8.0"/>
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0"/>
+    <Package id="Bonsai.Scripting.Python" version="0.2.1"/>
+    <Package id="Bonsai.System" version="2.8.0"/>
+    <Package id="IronPython" version="2.7.5"/>
+    <Package id="IronPython.StdLib" version="2.7.5"/>
+    <Package id="jacobslusser.ScintillaNET" version="3.6.3"/>
+    <Package id="Markdig" version="0.18.1"/>
+    <Package id="MathNet.Numerics" version="4.15.0"/>
+    <Package id="Microsoft.CSharp" version="4.7.0"/>
+    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
+    <Package id="Newtonsoft.Json" version="13.0.3"/>
+    <Package id="OxyPlot.Core" version="2.1.2"/>
+    <Package id="OxyPlot.WindowsForms" version="2.1.2"/>
+    <Package id="pythonnet" version="3.0.3"/>
+    <Package id="Rx-Core" version="2.2.5"/>
+    <Package id="Rx-Interfaces" version="2.2.5"/>
+    <Package id="Rx-Linq" version="2.2.5"/>
+    <Package id="Rx-PlatformServices" version="2.2.5"/>
+    <Package id="SvgNet" version="3.3.3"/>
+    <Package id="System.Linq.Dynamic" version="1.0.7"/>
+    <Package id="System.Reflection.Emit" version="4.3.0"/>
+    <Package id="YamlDotNet" version="13.1.1"/>
+    <Package id="ZedGraph" version="5.1.7"/>
+  </Packages>
+  <AssemblyReferences>
+    <AssemblyReference assemblyName="Bonsai"/>
+    <AssemblyReference assemblyName="Bonsai.Core"/>
+    <AssemblyReference assemblyName="Bonsai.Design"/>
+    <AssemblyReference assemblyName="Bonsai.Design.Visualizers"/>
+    <AssemblyReference assemblyName="Bonsai.Editor"/>
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems"/>
+    <AssemblyReference assemblyName="Bonsai.ML.Visualizers"/>
+    <AssemblyReference assemblyName="Bonsai.Numerics"/>
+    <AssemblyReference assemblyName="Bonsai.Scripting"/>
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions"/>
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design"/>
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython"/>
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design"/>
+    <AssemblyReference assemblyName="Bonsai.Scripting.Python"/>
+    <AssemblyReference assemblyName="Bonsai.System"/>
+  </AssemblyReferences>
+  <AssemblyLocations>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.2\lib\net48\Bonsai.exe"/>
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.1\lib\net472\Bonsai.Editor.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.0.1.1-build240320-01\lib\net472\Bonsai.ML.LinearDynamicalSystems.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.ML.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Visualizers.0.1.1-build240320-01\lib\net472\Bonsai.ML.Visualizers.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages\Bonsai.Numerics.0.9.0\lib\net462\Bonsai.Numerics.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.2.8.0\lib\net462\Bonsai.Scripting.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.2.8.0\lib\net462\Bonsai.Scripting.Expressions.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.2.8.0\lib\net462\Bonsai.Scripting.IronPython.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Python.0.2.1\lib\net472\Bonsai.Scripting.Python.dll"/>
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.0\lib\net462\Bonsai.System.dll"/>
+    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.dll"/>
+    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Modules.dll"/>
+    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.SQLite.dll"/>
+    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Wpf.dll"/>
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll"/>
+    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages\MathNet.Numerics.4.15.0\lib\net461\MathNet.Numerics.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Dynamic.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.AspNet.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.Metadata.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll"/>
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll"/>
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll"/>
+    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages\OxyPlot.Core.2.1.2\lib\net45\OxyPlot.dll"/>
+    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages\OxyPlot.WindowsForms.2.1.2\lib\net45\OxyPlot.WindowsForms.dll"/>
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages\pythonnet.3.0.3\lib\netstandard2.0\Python.Runtime.dll"/>
+    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll"/>
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll"/>
+    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll"/>
+    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll"/>
+    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll"/>
+    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll"/>
+    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll"/>
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.1.1\lib\net47\YamlDotNet.dll"/>
+    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages\ZedGraph.5.1.7\lib\net35-Client\ZedGraph.dll"/>
+  </AssemblyLocations>
+  <LibraryFolders>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native" platform="arm64"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native_uap" platform="arm64"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native" platform="x64"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native_uap" platform="x64"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native" platform="x86"/>
+    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86"/>
+  </LibraryFolders>
+</PackageConfiguration>

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/NuGet.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Gallery" value="Gallery" />
+    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
+    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Setup.ps1
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Setup.ps1
@@ -1,0 +1,19 @@
+if (!(Test-Path "./Bonsai.exe")) {
+    $release = "https://github.com/bonsai-rx/bonsai/releases/latest/download/Bonsai.zip"
+    $configPath = "./Bonsai.config"
+    if (Test-Path $configPath) {
+        [xml]$config = Get-Content $configPath
+        $bootstrapper = $config.PackageConfiguration.Packages.Package.where{$_.id -eq 'Bonsai'}
+        if ($bootstrapper) {
+            $version = $bootstrapper.version
+            $release = "https://github.com/bonsai-rx/bonsai/releases/download/$version/Bonsai.zip"
+        }
+    }
+    Invoke-WebRequest $release -OutFile "temp.zip"
+    Move-Item -Path "NuGet.config" "temp.config"
+    Expand-Archive "temp.zip" -DestinationPath "." -Force
+    Move-Item -Path "temp.config" "NuGet.config" -Force
+    Remove-Item -Path "temp.zip"
+	Remove-Item -Path "Bonsai32.exe"
+}
+& .\Bonsai.exe --no-editor

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Setup.sh
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Setup.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+CURRENT_DIR="$(pwd)"
+SETUP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd $SETUP_SCRIPT_DIR
+
+if [ ! -f "./Bonsai.exe" ]; then
+    CONFIG="./Bonsai.config"
+    if [ -f "$CONFIG" ]; then
+        VERSION=$(xmllint --xpath '//PackageConfiguration/Packages/Package[@id="Bonsai"]/@version' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+        RELEASE="https://github.com/bonsai-rx/bonsai/releases/download/$VERSION/Bonsai.zip"
+    else
+        RELEASE="https://github.com/bonsai-rx/bonsai/releases/latest/download/Bonsai.zip"
+    fi
+    wget $RELEASE -O "temp.zip"
+    mv -f "NuGet.config" "temp.config"
+    unzip -d "." -o "temp.zip"
+    mv -f "temp.config" "NuGet.config"
+    rm -rf "temp.zip"
+    rm -rf "Bonsai32.exe"
+fi
+
+source ./activate
+source ./run --no-editor
+cd $CURRENT_DIR

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/activate
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/activate
@@ -1,0 +1,14 @@
+#!/bin/bash
+# activate.sh
+if [[ -v BONSAI_EXE_PATH ]]; then
+    echo "Error! Cannot have multiple bonsai environments activated at the same time. Please deactivate the current environment before activating the new one."
+    return
+fi
+BONSAI_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+export BONSAI_EXE_PATH="$BONSAI_ENV_DIR/Bonsai.exe"
+export ORIGINAL_PS1="$PS1"
+export PS1="($(basename "$BONSAI_ENV_DIR")) $PS1"
+alias bonsai='source "$BONSAI_ENV_DIR"/run'
+alias bonsai-clean='GTK_DATA_PREFIX= source "$BONSAI_ENV_DIR"/run'
+alias deactivate='source "$BONSAI_ENV_DIR"/deactivate'
+echo "Activated bonsai environment in $BONSAI_ENV_DIR"

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/deactivate
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/deactivate
@@ -1,0 +1,8 @@
+#!/bin/bash
+unset BONSAI_EXE_PATH
+export PS1="$ORIGINAL_PS1"
+unset ORIGINAL_PS1
+unalias bonsai
+unalias bonsai-clean
+unalias deactivate
+echo "Deactivated bonsai environment."

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/run
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/run
@@ -1,0 +1,47 @@
+#!/bin/bash
+# run.sh
+
+CURRENT_DIR="$(pwd)"
+SETUP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd $SETUP_SCRIPT_DIR
+
+CONFIG="./Bonsai.config"
+BACKUP_CONFIG="${CONFIG}.backup"
+
+cleanup() {
+    update_paths_to_windows
+    cd $CURRENT_DIR
+}
+
+update_paths_to_linux() {
+    ASSEMBLYLOCATIONS=$(xmllint --xpath '//PackageConfiguration/AssemblyLocations/AssemblyLocation/@location' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+    for ASSEMBLYLOCATION in $ASSEMBLYLOCATIONS; do
+        NEWASSEMBLYLOCATION="${ASSEMBLYLOCATION//\\/\/}"
+        xmlstarlet edit --inplace --update "/PackageConfiguration/AssemblyLocations/AssemblyLocation[@location='$ASSEMBLYLOCATION']/@location" --value "$NEWASSEMBLYLOCATION" "$CONFIG"
+    done
+
+    LIBRARYFOLDERS=$(xmllint --xpath '//PackageConfiguration/LibraryFolders/LibraryFolder/@path' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+    for LIBRARYFOLDER in $LIBRARYFOLDERS; do
+        NEWLIBRARYFOLDER="${LIBRARYFOLDER//\\/\/}"
+        xmlstarlet edit --inplace --update "//PackageConfiguration/LibraryFolders/LibraryFolder[@path='$LIBRARYFOLDER']/@path" --value "$NEWLIBRARYFOLDER" "$CONFIG"
+    done
+}
+
+update_paths_to_windows() {
+    ASSEMBLYLOCATIONS=$(xmllint --xpath '//PackageConfiguration/AssemblyLocations/AssemblyLocation/@location' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+    for ASSEMBLYLOCATION in $ASSEMBLYLOCATIONS; do
+        NEWASSEMBLYLOCATION="${ASSEMBLYLOCATION//\//\\}"
+        xmlstarlet edit --inplace --update "/PackageConfiguration/AssemblyLocations/AssemblyLocation[@location='$ASSEMBLYLOCATION']/@location" --value "$NEWASSEMBLYLOCATION" "$CONFIG"
+    done
+
+    LIBRARYFOLDERS=$(xmllint --xpath '//PackageConfiguration/LibraryFolders/LibraryFolder/@path' "$CONFIG" | sed -e 's/^[^"]*"//' -e 's/"$//')
+    for LIBRARYFOLDER in $LIBRARYFOLDERS; do
+        NEWLIBRARYFOLDER="${LIBRARYFOLDER//\//\\}"
+        xmlstarlet edit --inplace --update "//PackageConfiguration/LibraryFolders/LibraryFolder[@path='$LIBRARYFOLDER']/@path" --value "$NEWLIBRARYFOLDER" "$CONFIG"
+    done
+}
+
+trap cleanup EXIT INT TERM
+update_paths_to_linux
+mono "$BONSAI_EXE_PATH" "$@"
+cleanup

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/README.md
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/README.md
@@ -1,0 +1,37 @@
+# Simulated Data
+
+The code for this repo can be found [here](https://github.com/bonsai-rx/machinelearning-examples/tree/main/examples/LinearDynamicalSystems/BayesianLinearRegression/SimulatedData).
+
+In the following example, you will see how the Kalman Filter can be used to perform Bayesian linear regression to estimate the parameters of a simple linear model with some added gaussian noise.
+
+### Dependencies
+
+If you used the bootstrapping method, you dont have to worry about the package dependencies, as these should be already installed. However, if creating a new environment or integrating into an existing one, you will need to install the following packages:
+
+* Bonsai - System v2.8.1
+* Bonsai - ML LinearDynamicalSystems v0.1.0
+* Bonsai - ML Visualizers v0.1.0
+
+### Workflow
+
+Below is the example workflow for how to perform bayesian linear regression with noisy data generated from a simple linear model.
+
+:::workflow
+![Linear Regression - Simulated Data](Simulation.bonsai)
+:::
+
+We use a linear model to generate simulated data. The linear model takes the form:
+
+$$Y_t = \beta_0 + \beta_1 X_t + \epsilon_t$$
+
+In the `SimulatedData` group node, we define the parameters of the linear model that are used to generate our data. We evaluate our linear model by passing in values of x, which are randomly selected from a uniform distribution. We then generate a noisy observation by taking the output of the model and adding some noise to the data by randomly sampling from a normal distribution.
+
+In the `CreateKFModel` node, we specify the number of features that will be included in our observations at each time step. Since our model has 2 parameters, we set the number of features to 2. We then specify the coefficients for our precision of the likelihood and the prior. 
+
+We wait for the model to initialize and then subscribe to the data observations using the `SubscribeWhen` node. As the workflow runs, the model will perform inference to learn the parameters of the underlying linear model used to generate the simuated data. We can then visualize the posterior of the model by creating a multivariate distribution over parameter space that covers a range of values around the true parameters of our linear model.
+
+To visualize the multivariate distribution, double click on the `CreateMultivariatePDF` node at the bottom of the workflow while it is running. You should see a heatmap visualization of the multivariate distribution. You can interact with this heatmap by left clicking to read the values at each pixel, right click to pan the image, or use the scroll wheel to zoom in/out. When you right click, you will see several options appear at the bottom of the visualizer's window where you can change the color palette and render method online. You can reset the plot to the original view by holding `Ctrl` and double right-click.
+
+The window should look like this:
+
+![Simulated Data](Simulation.gif)

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/Simulation.bonsai
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/Simulation.bonsai
@@ -1,0 +1,298 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
+                 xmlns:num="clr-namespace:Bonsai.Numerics;assembly=Bonsai.Numerics"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:Bonsai.Numerics.Distributions;assembly=Bonsai.Numerics"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
+                 xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:CreateRuntime" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:GetRuntime" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="GroupWorkflow">
+        <Name>SyntheticDataset</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Seed" DisplayName="RandomSeed" Category="1.Initialization" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="num:CreateRandom">
+                <num:Seed>0</num:Seed>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>RandomSeedSyntheticData</Name>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" DisplayName="a0" Category="2.LinearModel" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="DoubleProperty">
+                <Value>-0.3</Value>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>a0</Name>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" DisplayName="a1" Category="2.LinearModel" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="DoubleProperty">
+                <Value>0.5</Value>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>a1</Name>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" DisplayName="sigma" Category="3.Noise" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="DoubleProperty">
+                <Value>0.2</Value>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>sigma</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>RandomSeedSyntheticData</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p1:CreateContinuousUniform">
+                <p1:Lower>-1</p1:Lower>
+                <p1:Upper>1</p1:Upper>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>xDistribution</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>RandomSeedSyntheticData</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>sigma</Name>
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="StdDev" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p1:CreateNormal">
+                <p1:Mean>0</p1:Mean>
+                <p1:StdDev>0.2</p1:StdDev>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>GaussianNoise</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Timer">
+                <rx:DueTime>PT0S</rx:DueTime>
+                <rx:Period>PT1S</rx:Period>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:SelectMany">
+              <Name>SampleUniformDistribution</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>xDistribution</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="p1:Sample" />
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Take">
+                      <rx:Count>1</rx:Count>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="rx:SelectMany">
+              <Name>Evaluate</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>a0</Name>
+                  </Expression>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>a1</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="Multiply" />
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="Add" />
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="5" Label="Source1" />
+                  <Edge From="1" To="3" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source2" />
+                  <Edge From="3" To="4" Label="Source1" />
+                  <Edge From="4" To="5" Label="Source2" />
+                  <Edge From="5" To="6" Label="Source1" />
+                  <Edge From="6" To="7" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="rx:SelectMany">
+              <Name>AddNoise</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>GaussianNoise</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="p1:Sample" />
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="Add" />
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="3" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source2" />
+                  <Edge From="3" To="4" Label="Source1" />
+                  <Edge From="4" To="5" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Zip" />
+            </Expression>
+            <Expression xsi:type="scr:ExpressionTransform">
+              <scr:Expression>new(it.Item1 as X, it.Item2 as Y)</scr:Expression>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="8" Label="Source1" />
+            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="13" To="14" Label="Source1" />
+            <Edge From="15" To="18" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="17" To="18" Label="Source2" />
+            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="20" To="21" Label="Source1" />
+            <Edge From="21" To="22" Label="Source1" />
+            <Edge From="21" To="24" Label="Source1" />
+            <Edge From="22" To="23" Label="Source1" />
+            <Edge From="23" To="24" Label="Source2" />
+            <Edge From="24" To="25" Label="Source1" />
+            <Edge From="25" To="26" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>XYData</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>XYData</Name>
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>x=[{0}, 1],y={1}</Format>
+        <Selector>it.X,it.Y</Selector>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Observation</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>XYData</Name>
+      </Expression>
+      <Expression xsi:type="viz:LineGraphBuilder">
+        <viz:SymbolType>Circle</viz:SymbolType>
+        <viz:LineWidth>0</viz:LineWidth>
+        <viz:Capacity xsi:nil="true" />
+        <viz:XMin xsi:nil="true" />
+        <viz:XMax xsi:nil="true" />
+        <viz:YMin xsi:nil="true" />
+        <viz:YMax xsi:nil="true" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:GetRuntime" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.CreateKFModel.bonsai">
+        <LikelihoodPrecisionCoef>25</LikelihoodPrecisionCoef>
+        <PriorPrecisionCoef>2</PriorPrecisionCoef>
+        <N_features>2</N_features>
+        <Name>model</Name>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>ModelParams</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Observation</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>ModelParams</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:SubscribeWhen" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.PerformInference.bonsai">
+        <Name>model</Name>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.CreateMultivariatePDF.bonsai">
+        <Name>model</Name>
+        <X0>-1</X0>
+        <X1>1</X1>
+        <Xsteps>100</Xsteps>
+        <Y0>-1</Y0>
+        <Y1>1</Y1>
+        <Ysteps>100</Ysteps>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="12" Label="Source1" />
+      <Edge From="13" To="15" Label="Source1" />
+      <Edge From="14" To="15" Label="Source2" />
+      <Edge From="15" To="16" Label="Source1" />
+      <Edge From="16" To="17" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>


### PR DESCRIPTION
This PR adds 2 new examples to the repository. Both examples illustrate how to use the Bonsai.ML.LinearDynamicalSystems package to perform linear regression.

# Example 1 - Simulated Data

In this example, the LDS package is used to perform linear regression on simulated data that are generated from a simple linear model. In the example, the Kalman filter is fed noisy observations and is able to infer the underlying parameters of the linear model that are used to generate the data on a sample-by-sample basis.

# Example 2 - Receptive Field Simple Cell

In this example, the LDS package is used to estimate the receptive field of a simple cell recorded in V1 of an anaesthetised cat. While the example uses data that were collected in a previous experiment, it demonstrates how to infer the receptive field of a simple visual cell by performing bayesian inference on successive data points, which can easily be converted into an online experiment.