### PR TITLE
Update bootstrapper version and config file

### DIFF
--- a/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/Bonsai.config
@@ -1,133 +1,143 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.2"/>
-    <Package id="Bonsai.Core" version="2.8.1"/>
-    <Package id="Bonsai.Design" version="2.8.0"/>
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0"/>
-    <Package id="Bonsai.Dsp" version="2.8.0"/>
-    <Package id="Bonsai.Editor" version="2.8.1"/>
-    <Package id="Bonsai.ML" version="0.3.0"/>
-    <Package id="Bonsai.ML.Data" version="0.3.0"/>
-    <Package id="Bonsai.ML.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.Python" version="0.3.0"/>
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Python" version="0.2.1"/>
-    <Package id="Bonsai.System" version="2.8.1"/>
-    <Package id="Bonsai.Vision" version="2.8.1"/>
-    <Package id="Bonsai.Vision.Design" version="2.8.1"/>
-    <Package id="IronPython" version="2.7.5"/>
-    <Package id="IronPython.StdLib" version="2.7.5"/>
-    <Package id="jacobslusser.ScintillaNET" version="3.6.3"/>
-    <Package id="Markdig" version="0.18.1"/>
-    <Package id="MathNet.Numerics" version="5.0.0"/>
-    <Package id="Microsoft.CSharp" version="4.7.0"/>
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
-    <Package id="Newtonsoft.Json" version="13.0.3"/>
-    <Package id="OpenCV.Net" version="3.4.2"/>
-    <Package id="OpenTK" version="3.1.0"/>
-    <Package id="OpenTK.GLControl" version="3.1.0"/>
-    <Package id="OxyPlot.Core" version="2.1.2"/>
-    <Package id="OxyPlot.WindowsForms" version="2.1.2"/>
-    <Package id="pythonnet" version="3.0.3"/>
-    <Package id="Rx-Core" version="2.2.5"/>
-    <Package id="Rx-Interfaces" version="2.2.5"/>
-    <Package id="Rx-Linq" version="2.2.5"/>
-    <Package id="Rx-PlatformServices" version="2.2.5"/>
-    <Package id="SvgNet" version="3.3.3"/>
-    <Package id="System.Linq" version="4.3.0"/>
-    <Package id="System.Linq.Dynamic" version="1.0.7"/>
-    <Package id="System.Reflection.Emit" version="4.3.0"/>
-    <Package id="YamlDotNet" version="13.7.1"/>
-    <Package id="ZedGraph" version="5.1.7"/>
+    <Package id="Bonsai" version="2.8.5" />
+    <Package id="Bonsai.Core" version="2.8.5" />
+    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
+    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.ML" version="0.3.0" />
+    <Package id="Bonsai.ML.Data" version="0.3.0" />
+    <Package id="Bonsai.ML.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.Python" version="0.3.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
+    <Package id="Bonsai.System" version="2.8.1" />
+    <Package id="Bonsai.Vision" version="2.8.1" />
+    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="IronPython" version="2.7.5" />
+    <Package id="IronPython.StdLib" version="2.7.5" />
+    <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
+    <Package id="Markdig" version="0.18.1" />
+    <Package id="MathNet.Numerics" version="5.0.0" />
+    <Package id="Microsoft.CSharp" version="4.7.0" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Newtonsoft.Json" version="13.0.3" />
+    <Package id="OpenCV.Net" version="3.4.2" />
+    <Package id="OpenTK" version="3.1.0" />
+    <Package id="OpenTK.GLControl" version="3.1.0" />
+    <Package id="OxyPlot.Core" version="2.1.2" />
+    <Package id="OxyPlot.WindowsForms" version="2.1.2" />
+    <Package id="pythonnet" version="3.0.3" />
+    <Package id="Rx-Core" version="2.2.5" />
+    <Package id="Rx-Interfaces" version="2.2.5" />
+    <Package id="Rx-Linq" version="2.2.5" />
+    <Package id="Rx-PlatformServices" version="2.2.5" />
+    <Package id="SvgNet" version="3.3.3" />
+    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="System.Linq" version="4.3.0" />
+    <Package id="System.Linq.Dynamic" version="1.0.7" />
+    <Package id="System.Memory" version="4.5.5" />
+    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Reflection.Emit" version="4.3.0" />
+    <Package id="System.Resources.Extensions" version="8.0.0" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
+    <Package id="YamlDotNet" version="13.7.1" />
+    <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
-    <AssemblyReference assemblyName="Bonsai"/>
-    <AssemblyReference assemblyName="Bonsai.Core"/>
-    <AssemblyReference assemblyName="Bonsai.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Design.Visualizers"/>
-    <AssemblyReference assemblyName="Bonsai.Dsp"/>
-    <AssemblyReference assemblyName="Bonsai.Editor"/>
-    <AssemblyReference assemblyName="Bonsai.ML"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Data"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Python"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Python"/>
-    <AssemblyReference assemblyName="Bonsai.System"/>
-    <AssemblyReference assemblyName="Bonsai.Vision"/>
-    <AssemblyReference assemblyName="Bonsai.Vision.Design"/>
+    <AssemblyReference assemblyName="Bonsai" />
+    <AssemblyReference assemblyName="Bonsai.Core" />
+    <AssemblyReference assemblyName="Bonsai.Design" />
+    <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
+    <AssemblyReference assemblyName="Bonsai.Dsp" />
+    <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.ML" />
+    <AssemblyReference assemblyName="Bonsai.ML.Data" />
+    <AssemblyReference assemblyName="Bonsai.ML.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Python" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
+    <AssemblyReference assemblyName="Bonsai.System" />
+    <AssemblyReference assemblyName="Bonsai.Vision" />
+    <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.2\lib\net48\Bonsai.exe"/>
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.1\lib\net472\Bonsai.Editor.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages\Bonsai.ML.0.3.0\lib\net472\Bonsai.ML.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Data.0.3.0\lib\net472\Bonsai.ML.Data.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Design.0.3.0\lib\net472\Bonsai.ML.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.Design.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Python.0.3.0\lib\net472\Bonsai.ML.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.2.8.0\lib\net462\Bonsai.Scripting.Expressions.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.2.8.0\lib\net462\Bonsai.Scripting.IronPython.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Python.0.2.1\lib\net472\Bonsai.Scripting.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.1\lib\net462\Bonsai.Vision.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.1\lib\net462\Bonsai.Vision.Design.dll"/>
-    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Modules.dll"/>
-    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.SQLite.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll"/>
-    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.AspNet.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.Metadata.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll"/>
-    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages\OpenCV.Net.3.4.2\lib\net462\OpenCV.Net.dll"/>
-    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages\OpenTK.3.1.0\lib\net20\OpenTK.dll"/>
-    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages\OxyPlot.Core.2.1.2\lib\net45\OxyPlot.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages\OxyPlot.WindowsForms.2.1.2\lib\net45\OxyPlot.WindowsForms.dll"/>
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages\pythonnet.3.0.3\lib\netstandard2.0\Python.Runtime.dll"/>
-    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll"/>
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll"/>
-    <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages\System.Linq.4.3.0\lib\net463\System.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll"/>
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.7.1\lib\net47\YamlDotNet.dll"/>
-    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages\ZedGraph.5.1.7\lib\net35-Client\ZedGraph.dll"/>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.0/lib/net472/Bonsai.ML.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.0/lib/net472/Bonsai.ML.Data.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.0/lib/net472/Bonsai.ML.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.3.0/lib/net472/Bonsai.ML.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
+    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
+    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
+    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
+    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
+    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
+    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
+    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
+    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages/System.Linq.4.3.0/lib/net463/System.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
+    <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.7.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native_uap" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native_uap" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native" platform="x86"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x64\native\vc14\bin" platform="x64"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x86\native\vc14\bin" platform="x86"/>
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>
 </PackageConfiguration>

--- a/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/Bonsai.config
@@ -1,136 +1,146 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.2"/>
-    <Package id="Bonsai.Core" version="2.8.1"/>
-    <Package id="Bonsai.Design" version="2.8.0"/>
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0"/>
-    <Package id="Bonsai.Dsp" version="2.8.0"/>
-    <Package id="Bonsai.Editor" version="2.8.1"/>
-    <Package id="Bonsai.ML" version="0.3.0"/>
-    <Package id="Bonsai.ML.Data" version="0.3.0"/>
-    <Package id="Bonsai.ML.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.Python" version="0.3.0"/>
-    <Package id="Bonsai.Scripting" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Python" version="0.2.1"/>
-    <Package id="Bonsai.System" version="2.8.0"/>
-    <Package id="Bonsai.Vision" version="2.8.0"/>
-    <Package id="Bonsai.Vision.Design" version="2.8.1"/>
-    <Package id="IronPython" version="2.7.5"/>
-    <Package id="IronPython.StdLib" version="2.7.5"/>
-    <Package id="jacobslusser.ScintillaNET" version="3.6.3"/>
-    <Package id="Markdig" version="0.18.1"/>
-    <Package id="MathNet.Numerics" version="5.0.0"/>
-    <Package id="Microsoft.CSharp" version="4.7.0"/>
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
-    <Package id="Newtonsoft.Json" version="13.0.3"/>
-    <Package id="OpenCV.Net" version="3.4.2"/>
-    <Package id="OpenTK" version="3.1.0"/>
-    <Package id="OpenTK.GLControl" version="3.1.0"/>
-    <Package id="OxyPlot.Core" version="2.1.2"/>
-    <Package id="OxyPlot.WindowsForms" version="2.1.2"/>
-    <Package id="pythonnet" version="3.0.3"/>
-    <Package id="Rx-Core" version="2.2.5"/>
-    <Package id="Rx-Interfaces" version="2.2.5"/>
-    <Package id="Rx-Linq" version="2.2.5"/>
-    <Package id="Rx-PlatformServices" version="2.2.5"/>
-    <Package id="SvgNet" version="3.3.3"/>
-    <Package id="System.Linq" version="4.3.0"/>
-    <Package id="System.Linq.Dynamic" version="1.0.7"/>
-    <Package id="System.Reflection.Emit" version="4.3.0"/>
-    <Package id="YamlDotNet" version="13.1.1"/>
-    <Package id="ZedGraph" version="5.1.7"/>
+    <Package id="Bonsai" version="2.8.5" />
+    <Package id="Bonsai.Core" version="2.8.5" />
+    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
+    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.ML" version="0.3.0" />
+    <Package id="Bonsai.ML.Data" version="0.3.0" />
+    <Package id="Bonsai.ML.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.Python" version="0.3.0" />
+    <Package id="Bonsai.Scripting" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
+    <Package id="Bonsai.System" version="2.8.1" />
+    <Package id="Bonsai.Vision" version="2.8.1" />
+    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="IronPython" version="2.7.5" />
+    <Package id="IronPython.StdLib" version="2.7.5" />
+    <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
+    <Package id="Markdig" version="0.18.1" />
+    <Package id="MathNet.Numerics" version="5.0.0" />
+    <Package id="Microsoft.CSharp" version="4.7.0" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Newtonsoft.Json" version="13.0.3" />
+    <Package id="OpenCV.Net" version="3.4.2" />
+    <Package id="OpenTK" version="3.1.0" />
+    <Package id="OpenTK.GLControl" version="3.1.0" />
+    <Package id="OxyPlot.Core" version="2.1.2" />
+    <Package id="OxyPlot.WindowsForms" version="2.1.2" />
+    <Package id="pythonnet" version="3.0.3" />
+    <Package id="Rx-Core" version="2.2.5" />
+    <Package id="Rx-Interfaces" version="2.2.5" />
+    <Package id="Rx-Linq" version="2.2.5" />
+    <Package id="Rx-PlatformServices" version="2.2.5" />
+    <Package id="SvgNet" version="3.3.3" />
+    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="System.Linq" version="4.3.0" />
+    <Package id="System.Linq.Dynamic" version="1.0.7" />
+    <Package id="System.Memory" version="4.5.5" />
+    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Reflection.Emit" version="4.3.0" />
+    <Package id="System.Resources.Extensions" version="8.0.0" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
+    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
-    <AssemblyReference assemblyName="Bonsai"/>
-    <AssemblyReference assemblyName="Bonsai.Core"/>
-    <AssemblyReference assemblyName="Bonsai.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Design.Visualizers"/>
-    <AssemblyReference assemblyName="Bonsai.Dsp"/>
-    <AssemblyReference assemblyName="Bonsai.Editor"/>
-    <AssemblyReference assemblyName="Bonsai.ML"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Data"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Python"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Python"/>
-    <AssemblyReference assemblyName="Bonsai.System"/>
-    <AssemblyReference assemblyName="Bonsai.Vision"/>
-    <AssemblyReference assemblyName="Bonsai.Vision.Design"/>
+    <AssemblyReference assemblyName="Bonsai" />
+    <AssemblyReference assemblyName="Bonsai.Core" />
+    <AssemblyReference assemblyName="Bonsai.Design" />
+    <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
+    <AssemblyReference assemblyName="Bonsai.Dsp" />
+    <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.ML" />
+    <AssemblyReference assemblyName="Bonsai.ML.Data" />
+    <AssemblyReference assemblyName="Bonsai.ML.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Python" />
+    <AssemblyReference assemblyName="Bonsai.Scripting" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
+    <AssemblyReference assemblyName="Bonsai.System" />
+    <AssemblyReference assemblyName="Bonsai.Vision" />
+    <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.2\lib\net48\Bonsai.exe"/>
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.1\lib\net472\Bonsai.Editor.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages\Bonsai.ML.0.3.0\lib\net472\Bonsai.ML.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Data.0.3.0\lib\net472\Bonsai.ML.Data.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Design.0.3.0\lib\net472\Bonsai.ML.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.Design.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Python.0.3.0\lib\net472\Bonsai.ML.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.2.8.0\lib\net462\Bonsai.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.2.8.0\lib\net462\Bonsai.Scripting.Expressions.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.2.8.0\lib\net462\Bonsai.Scripting.IronPython.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Python.0.2.1\lib\net472\Bonsai.Scripting.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.0\lib\net462\Bonsai.System.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.0\lib\net462\Bonsai.Vision.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.1\lib\net462\Bonsai.Vision.Design.dll"/>
-    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Modules.dll"/>
-    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.SQLite.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll"/>
-    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.AspNet.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.Metadata.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll"/>
-    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages\OpenCV.Net.3.4.2\lib\net462\OpenCV.Net.dll"/>
-    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages\OpenTK.3.1.0\lib\net20\OpenTK.dll"/>
-    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages\OxyPlot.Core.2.1.2\lib\net45\OxyPlot.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages\OxyPlot.WindowsForms.2.1.2\lib\net45\OxyPlot.WindowsForms.dll"/>
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages\pythonnet.3.0.3\lib\netstandard2.0\Python.Runtime.dll"/>
-    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll"/>
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll"/>
-    <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages\System.Linq.4.3.0\lib\net463\System.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll"/>
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.1.1\lib\net47\YamlDotNet.dll"/>
-    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages\ZedGraph.5.1.7\lib\net35-Client\ZedGraph.dll"/>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.0/lib/net472/Bonsai.ML.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.0/lib/net472/Bonsai.ML.Data.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.0/lib/net472/Bonsai.ML.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.3.0/lib/net472/Bonsai.ML.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
+    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
+    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
+    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
+    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
+    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
+    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
+    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
+    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages/System.Linq.4.3.0/lib/net463/System.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
+    <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native_uap" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native_uap" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native" platform="x86"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x64\native\vc14\bin" platform="x64"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x86\native\vc14\bin" platform="x86"/>
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>
 </PackageConfiguration>

--- a/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/Bonsai.config
@@ -1,134 +1,144 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.2"/>
-    <Package id="Bonsai.Core" version="2.8.1"/>
-    <Package id="Bonsai.Design" version="2.8.0"/>
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0"/>
-    <Package id="Bonsai.Dsp" version="2.8.0"/>
-    <Package id="Bonsai.Editor" version="2.8.1"/>
-    <Package id="Bonsai.ML" version="0.3.0"/>
-    <Package id="Bonsai.ML.Data" version="0.3.0"/>
-    <Package id="Bonsai.ML.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.Python" version="0.3.0"/>
-    <Package id="Bonsai.Scripting" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Python" version="0.2.1"/>
-    <Package id="Bonsai.System" version="2.8.0"/>
-    <Package id="Bonsai.Vision" version="2.8.0"/>
-    <Package id="Bonsai.Vision.Design" version="2.8.1"/>
-    <Package id="IronPython" version="2.7.5"/>
-    <Package id="IronPython.StdLib" version="2.7.5"/>
-    <Package id="jacobslusser.ScintillaNET" version="3.6.3"/>
-    <Package id="Markdig" version="0.18.1"/>
-    <Package id="MathNet.Numerics" version="5.0.0"/>
-    <Package id="Microsoft.CSharp" version="4.7.0"/>
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
-    <Package id="Newtonsoft.Json" version="13.0.3"/>
-    <Package id="OpenCV.Net" version="3.4.2"/>
-    <Package id="OpenTK" version="3.1.0"/>
-    <Package id="OpenTK.GLControl" version="3.1.0"/>
-    <Package id="OxyPlot.Core" version="2.1.2"/>
-    <Package id="OxyPlot.WindowsForms" version="2.1.2"/>
-    <Package id="pythonnet" version="3.0.3"/>
-    <Package id="Rx-Core" version="2.2.5"/>
-    <Package id="Rx-Interfaces" version="2.2.5"/>
-    <Package id="Rx-Linq" version="2.2.5"/>
-    <Package id="Rx-PlatformServices" version="2.2.5"/>
-    <Package id="SvgNet" version="3.3.3"/>
-    <Package id="System.Linq.Dynamic" version="1.0.7"/>
-    <Package id="System.Reflection.Emit" version="4.3.0"/>
-    <Package id="YamlDotNet" version="13.1.1"/>
-    <Package id="ZedGraph" version="5.1.7"/>
+    <Package id="Bonsai" version="2.8.5" />
+    <Package id="Bonsai.Core" version="2.8.5" />
+    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
+    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.ML" version="0.3.0" />
+    <Package id="Bonsai.ML.Data" version="0.3.0" />
+    <Package id="Bonsai.ML.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.Python" version="0.3.0" />
+    <Package id="Bonsai.Scripting" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
+    <Package id="Bonsai.System" version="2.8.1" />
+    <Package id="Bonsai.Vision" version="2.8.1" />
+    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="IronPython" version="2.7.5" />
+    <Package id="IronPython.StdLib" version="2.7.5" />
+    <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
+    <Package id="Markdig" version="0.18.1" />
+    <Package id="MathNet.Numerics" version="5.0.0" />
+    <Package id="Microsoft.CSharp" version="4.7.0" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Newtonsoft.Json" version="13.0.3" />
+    <Package id="OpenCV.Net" version="3.4.2" />
+    <Package id="OpenTK" version="3.1.0" />
+    <Package id="OpenTK.GLControl" version="3.1.0" />
+    <Package id="OxyPlot.Core" version="2.1.2" />
+    <Package id="OxyPlot.WindowsForms" version="2.1.2" />
+    <Package id="pythonnet" version="3.0.3" />
+    <Package id="Rx-Core" version="2.2.5" />
+    <Package id="Rx-Interfaces" version="2.2.5" />
+    <Package id="Rx-Linq" version="2.2.5" />
+    <Package id="Rx-PlatformServices" version="2.2.5" />
+    <Package id="SvgNet" version="3.3.3" />
+    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="System.Linq.Dynamic" version="1.0.7" />
+    <Package id="System.Memory" version="4.5.5" />
+    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Reflection.Emit" version="4.3.0" />
+    <Package id="System.Resources.Extensions" version="8.0.0" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
+    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
-    <AssemblyReference assemblyName="Bonsai"/>
-    <AssemblyReference assemblyName="Bonsai.Core"/>
-    <AssemblyReference assemblyName="Bonsai.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Design.Visualizers"/>
-    <AssemblyReference assemblyName="Bonsai.Dsp"/>
-    <AssemblyReference assemblyName="Bonsai.Editor"/>
-    <AssemblyReference assemblyName="Bonsai.ML"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Data"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Python"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Python"/>
-    <AssemblyReference assemblyName="Bonsai.System"/>
-    <AssemblyReference assemblyName="Bonsai.Vision"/>
-    <AssemblyReference assemblyName="Bonsai.Vision.Design"/>
+    <AssemblyReference assemblyName="Bonsai" />
+    <AssemblyReference assemblyName="Bonsai.Core" />
+    <AssemblyReference assemblyName="Bonsai.Design" />
+    <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
+    <AssemblyReference assemblyName="Bonsai.Dsp" />
+    <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.ML" />
+    <AssemblyReference assemblyName="Bonsai.ML.Data" />
+    <AssemblyReference assemblyName="Bonsai.ML.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Python" />
+    <AssemblyReference assemblyName="Bonsai.Scripting" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
+    <AssemblyReference assemblyName="Bonsai.System" />
+    <AssemblyReference assemblyName="Bonsai.Vision" />
+    <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.2\lib\net48\Bonsai.exe"/>
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.1\lib\net472\Bonsai.Editor.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages\Bonsai.ML.0.3.0\lib\net472\Bonsai.ML.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Data.0.3.0\lib\net472\Bonsai.ML.Data.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Design.0.3.0\lib\net472\Bonsai.ML.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.Design.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Python.0.3.0\lib\net472\Bonsai.ML.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.2.8.0\lib\net462\Bonsai.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.2.8.0\lib\net462\Bonsai.Scripting.Expressions.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.2.8.0\lib\net462\Bonsai.Scripting.IronPython.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Python.0.2.1\lib\net472\Bonsai.Scripting.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.0\lib\net462\Bonsai.System.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.0\lib\net462\Bonsai.Vision.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.1\lib\net462\Bonsai.Vision.Design.dll"/>
-    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Modules.dll"/>
-    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.SQLite.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll"/>
-    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.AspNet.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.Metadata.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll"/>
-    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages\OpenCV.Net.3.4.2\lib\net462\OpenCV.Net.dll"/>
-    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages\OpenTK.3.1.0\lib\net20\OpenTK.dll"/>
-    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages\OxyPlot.Core.2.1.2\lib\net45\OxyPlot.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages\OxyPlot.WindowsForms.2.1.2\lib\net45\OxyPlot.WindowsForms.dll"/>
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages\pythonnet.3.0.3\lib\netstandard2.0\Python.Runtime.dll"/>
-    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll"/>
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll"/>
-    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll"/>
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.1.1\lib\net47\YamlDotNet.dll"/>
-    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages\ZedGraph.5.1.7\lib\net35-Client\ZedGraph.dll"/>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.0/lib/net472/Bonsai.ML.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.0/lib/net472/Bonsai.ML.Data.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.0/lib/net472/Bonsai.ML.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.3.0/lib/net472/Bonsai.ML.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
+    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
+    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
+    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
+    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
+    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
+    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
+    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
+    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
+    <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native_uap" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native_uap" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native" platform="x86"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x64\native\vc14\bin" platform="x64"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x86\native\vc14\bin" platform="x86"/>
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>
 </PackageConfiguration>

--- a/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/Bonsai.config
@@ -1,139 +1,149 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.2"/>
-    <Package id="Bonsai.Core" version="2.8.1"/>
-    <Package id="Bonsai.Design" version="2.8.0"/>
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0"/>
-    <Package id="Bonsai.Dsp" version="2.8.0"/>
-    <Package id="Bonsai.Editor" version="2.8.1"/>
-    <Package id="Bonsai.ML" version="0.3.0"/>
-    <Package id="Bonsai.ML.Data" version="0.3.0"/>
-    <Package id="Bonsai.ML.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.Python" version="0.3.0"/>
-    <Package id="Bonsai.Numerics" version="0.9.0"/>
-    <Package id="Bonsai.Scripting" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Python" version="0.2.1"/>
-    <Package id="Bonsai.System" version="2.8.1"/>
-    <Package id="Bonsai.Vision" version="2.8.1"/>
-    <Package id="Bonsai.Vision.Design" version="2.8.1"/>
-    <Package id="IronPython" version="2.7.5"/>
-    <Package id="IronPython.StdLib" version="2.7.5"/>
-    <Package id="jacobslusser.ScintillaNET" version="3.6.3"/>
-    <Package id="Markdig" version="0.18.1"/>
-    <Package id="MathNet.Numerics" version="5.0.0"/>
-    <Package id="Microsoft.CSharp" version="4.7.0"/>
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
-    <Package id="Newtonsoft.Json" version="13.0.3"/>
-    <Package id="OpenCV.Net" version="3.4.2"/>
-    <Package id="OpenTK" version="3.1.0"/>
-    <Package id="OpenTK.GLControl" version="3.1.0"/>
-    <Package id="OxyPlot.Core" version="2.1.2"/>
-    <Package id="OxyPlot.WindowsForms" version="2.1.2"/>
-    <Package id="pythonnet" version="3.0.3"/>
-    <Package id="Rx-Core" version="2.2.5"/>
-    <Package id="Rx-Interfaces" version="2.2.5"/>
-    <Package id="Rx-Linq" version="2.2.5"/>
-    <Package id="Rx-PlatformServices" version="2.2.5"/>
-    <Package id="SvgNet" version="3.3.3"/>
-    <Package id="System.Linq" version="4.3.0"/>
-    <Package id="System.Linq.Dynamic" version="1.0.7"/>
-    <Package id="System.Reflection.Emit" version="4.3.0"/>
-    <Package id="YamlDotNet" version="13.7.1"/>
-    <Package id="ZedGraph" version="5.1.7"/>
+    <Package id="Bonsai" version="2.8.5" />
+    <Package id="Bonsai.Core" version="2.8.5" />
+    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
+    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.ML" version="0.3.0" />
+    <Package id="Bonsai.ML.Data" version="0.3.0" />
+    <Package id="Bonsai.ML.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.Python" version="0.3.0" />
+    <Package id="Bonsai.Numerics" version="0.9.0" />
+    <Package id="Bonsai.Scripting" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
+    <Package id="Bonsai.System" version="2.8.1" />
+    <Package id="Bonsai.Vision" version="2.8.1" />
+    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="IronPython" version="2.7.5" />
+    <Package id="IronPython.StdLib" version="2.7.5" />
+    <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
+    <Package id="Markdig" version="0.18.1" />
+    <Package id="MathNet.Numerics" version="5.0.0" />
+    <Package id="Microsoft.CSharp" version="4.7.0" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Newtonsoft.Json" version="13.0.3" />
+    <Package id="OpenCV.Net" version="3.4.2" />
+    <Package id="OpenTK" version="3.1.0" />
+    <Package id="OpenTK.GLControl" version="3.1.0" />
+    <Package id="OxyPlot.Core" version="2.1.2" />
+    <Package id="OxyPlot.WindowsForms" version="2.1.2" />
+    <Package id="pythonnet" version="3.0.3" />
+    <Package id="Rx-Core" version="2.2.5" />
+    <Package id="Rx-Interfaces" version="2.2.5" />
+    <Package id="Rx-Linq" version="2.2.5" />
+    <Package id="Rx-PlatformServices" version="2.2.5" />
+    <Package id="SvgNet" version="3.3.3" />
+    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="System.Linq" version="4.3.0" />
+    <Package id="System.Linq.Dynamic" version="1.0.7" />
+    <Package id="System.Memory" version="4.5.5" />
+    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Reflection.Emit" version="4.3.0" />
+    <Package id="System.Resources.Extensions" version="8.0.0" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
+    <Package id="YamlDotNet" version="13.7.1" />
+    <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
-    <AssemblyReference assemblyName="Bonsai"/>
-    <AssemblyReference assemblyName="Bonsai.Core"/>
-    <AssemblyReference assemblyName="Bonsai.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Design.Visualizers"/>
-    <AssemblyReference assemblyName="Bonsai.Dsp"/>
-    <AssemblyReference assemblyName="Bonsai.Editor"/>
-    <AssemblyReference assemblyName="Bonsai.ML"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Data"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Python"/>
-    <AssemblyReference assemblyName="Bonsai.Numerics"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Python"/>
-    <AssemblyReference assemblyName="Bonsai.System"/>
-    <AssemblyReference assemblyName="Bonsai.Vision"/>
-    <AssemblyReference assemblyName="Bonsai.Vision.Design"/>
+    <AssemblyReference assemblyName="Bonsai" />
+    <AssemblyReference assemblyName="Bonsai.Core" />
+    <AssemblyReference assemblyName="Bonsai.Design" />
+    <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
+    <AssemblyReference assemblyName="Bonsai.Dsp" />
+    <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.ML" />
+    <AssemblyReference assemblyName="Bonsai.ML.Data" />
+    <AssemblyReference assemblyName="Bonsai.ML.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Python" />
+    <AssemblyReference assemblyName="Bonsai.Numerics" />
+    <AssemblyReference assemblyName="Bonsai.Scripting" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
+    <AssemblyReference assemblyName="Bonsai.System" />
+    <AssemblyReference assemblyName="Bonsai.Vision" />
+    <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.2\lib\net48\Bonsai.exe"/>
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.1\lib\net472\Bonsai.Editor.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages\Bonsai.ML.0.3.0\lib\net472\Bonsai.ML.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Data.0.3.0\lib\net472\Bonsai.ML.Data.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Design.0.3.0\lib\net472\Bonsai.ML.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.Design.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Python.0.3.0\lib\net472\Bonsai.ML.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages\Bonsai.Numerics.0.9.0\lib\net462\Bonsai.Numerics.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.2.8.0\lib\net462\Bonsai.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.2.8.0\lib\net462\Bonsai.Scripting.Expressions.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.2.8.0\lib\net462\Bonsai.Scripting.IronPython.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Python.0.2.1\lib\net472\Bonsai.Scripting.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.1\lib\net462\Bonsai.Vision.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.1\lib\net462\Bonsai.Vision.Design.dll"/>
-    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Modules.dll"/>
-    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.SQLite.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll"/>
-    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.AspNet.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.Metadata.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll"/>
-    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages\OpenCV.Net.3.4.2\lib\net462\OpenCV.Net.dll"/>
-    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages\OpenTK.3.1.0\lib\net20\OpenTK.dll"/>
-    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages\OxyPlot.Core.2.1.2\lib\net45\OxyPlot.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages\OxyPlot.WindowsForms.2.1.2\lib\net45\OxyPlot.WindowsForms.dll"/>
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages\pythonnet.3.0.3\lib\netstandard2.0\Python.Runtime.dll"/>
-    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll"/>
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll"/>
-    <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages\System.Linq.4.3.0\lib\net463\System.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll"/>
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.7.1\lib\net47\YamlDotNet.dll"/>
-    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages\ZedGraph.5.1.7\lib\net35-Client\ZedGraph.dll"/>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.0/lib/net472/Bonsai.ML.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.0/lib/net472/Bonsai.ML.Data.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.0/lib/net472/Bonsai.ML.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.3.0/lib/net472/Bonsai.ML.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.9.0/lib/net462/Bonsai.Numerics.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
+    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
+    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
+    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
+    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
+    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
+    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
+    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
+    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages/System.Linq.4.3.0/lib/net463/System.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
+    <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.7.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native_uap" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native_uap" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native" platform="x86"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x64\native\vc14\bin" platform="x64"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x86\native\vc14\bin" platform="x86"/>
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>
 </PackageConfiguration>

--- a/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/Bonsai.config
@@ -1,136 +1,146 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.2"/>
-    <Package id="Bonsai.Core" version="2.8.1"/>
-    <Package id="Bonsai.Design" version="2.8.0"/>
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0"/>
-    <Package id="Bonsai.Dsp" version="2.8.0"/>
-    <Package id="Bonsai.Editor" version="2.8.1"/>
-    <Package id="Bonsai.ML" version="0.3.0"/>
-    <Package id="Bonsai.ML.Data" version="0.3.0"/>
-    <Package id="Bonsai.ML.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.Python" version="0.3.0"/>
-    <Package id="Bonsai.Scripting" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Python" version="0.2.1"/>
-    <Package id="Bonsai.System" version="2.8.1"/>
-    <Package id="Bonsai.Vision" version="2.8.1"/>
-    <Package id="Bonsai.Vision.Design" version="2.8.1"/>
-    <Package id="IronPython" version="2.7.5"/>
-    <Package id="IronPython.StdLib" version="2.7.5"/>
-    <Package id="jacobslusser.ScintillaNET" version="3.6.3"/>
-    <Package id="Markdig" version="0.18.1"/>
-    <Package id="MathNet.Numerics" version="5.0.0"/>
-    <Package id="Microsoft.CSharp" version="4.7.0"/>
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
-    <Package id="Newtonsoft.Json" version="13.0.3"/>
-    <Package id="OpenCV.Net" version="3.4.2"/>
-    <Package id="OpenTK" version="3.1.0"/>
-    <Package id="OpenTK.GLControl" version="3.1.0"/>
-    <Package id="OxyPlot.Core" version="2.1.2"/>
-    <Package id="OxyPlot.WindowsForms" version="2.1.2"/>
-    <Package id="pythonnet" version="3.0.3"/>
-    <Package id="Rx-Core" version="2.2.5"/>
-    <Package id="Rx-Interfaces" version="2.2.5"/>
-    <Package id="Rx-Linq" version="2.2.5"/>
-    <Package id="Rx-PlatformServices" version="2.2.5"/>
-    <Package id="SvgNet" version="3.3.3"/>
-    <Package id="System.Linq" version="4.3.0"/>
-    <Package id="System.Linq.Dynamic" version="1.0.7"/>
-    <Package id="System.Reflection.Emit" version="4.3.0"/>
-    <Package id="YamlDotNet" version="13.7.1"/>
-    <Package id="ZedGraph" version="5.1.7"/>
+    <Package id="Bonsai" version="2.8.5" />
+    <Package id="Bonsai.Core" version="2.8.5" />
+    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
+    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.ML" version="0.3.0" />
+    <Package id="Bonsai.ML.Data" version="0.3.0" />
+    <Package id="Bonsai.ML.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.Python" version="0.3.0" />
+    <Package id="Bonsai.Scripting" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
+    <Package id="Bonsai.System" version="2.8.1" />
+    <Package id="Bonsai.Vision" version="2.8.1" />
+    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="IronPython" version="2.7.5" />
+    <Package id="IronPython.StdLib" version="2.7.5" />
+    <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
+    <Package id="Markdig" version="0.18.1" />
+    <Package id="MathNet.Numerics" version="5.0.0" />
+    <Package id="Microsoft.CSharp" version="4.7.0" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Newtonsoft.Json" version="13.0.3" />
+    <Package id="OpenCV.Net" version="3.4.2" />
+    <Package id="OpenTK" version="3.1.0" />
+    <Package id="OpenTK.GLControl" version="3.1.0" />
+    <Package id="OxyPlot.Core" version="2.1.2" />
+    <Package id="OxyPlot.WindowsForms" version="2.1.2" />
+    <Package id="pythonnet" version="3.0.3" />
+    <Package id="Rx-Core" version="2.2.5" />
+    <Package id="Rx-Interfaces" version="2.2.5" />
+    <Package id="Rx-Linq" version="2.2.5" />
+    <Package id="Rx-PlatformServices" version="2.2.5" />
+    <Package id="SvgNet" version="3.3.3" />
+    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="System.Linq" version="4.3.0" />
+    <Package id="System.Linq.Dynamic" version="1.0.7" />
+    <Package id="System.Memory" version="4.5.5" />
+    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Reflection.Emit" version="4.3.0" />
+    <Package id="System.Resources.Extensions" version="8.0.0" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
+    <Package id="YamlDotNet" version="13.7.1" />
+    <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
-    <AssemblyReference assemblyName="Bonsai"/>
-    <AssemblyReference assemblyName="Bonsai.Core"/>
-    <AssemblyReference assemblyName="Bonsai.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Design.Visualizers"/>
-    <AssemblyReference assemblyName="Bonsai.Dsp"/>
-    <AssemblyReference assemblyName="Bonsai.Editor"/>
-    <AssemblyReference assemblyName="Bonsai.ML"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Data"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Python"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Python"/>
-    <AssemblyReference assemblyName="Bonsai.System"/>
-    <AssemblyReference assemblyName="Bonsai.Vision"/>
-    <AssemblyReference assemblyName="Bonsai.Vision.Design"/>
+    <AssemblyReference assemblyName="Bonsai" />
+    <AssemblyReference assemblyName="Bonsai.Core" />
+    <AssemblyReference assemblyName="Bonsai.Design" />
+    <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
+    <AssemblyReference assemblyName="Bonsai.Dsp" />
+    <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.ML" />
+    <AssemblyReference assemblyName="Bonsai.ML.Data" />
+    <AssemblyReference assemblyName="Bonsai.ML.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Python" />
+    <AssemblyReference assemblyName="Bonsai.Scripting" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
+    <AssemblyReference assemblyName="Bonsai.System" />
+    <AssemblyReference assemblyName="Bonsai.Vision" />
+    <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.2\lib\net48\Bonsai.exe"/>
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.1\lib\net472\Bonsai.Editor.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages\Bonsai.ML.0.3.0\lib\net472\Bonsai.ML.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Data.0.3.0\lib\net472\Bonsai.ML.Data.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Design.0.3.0\lib\net472\Bonsai.ML.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.Design.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Python.0.3.0\lib\net472\Bonsai.ML.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.2.8.0\lib\net462\Bonsai.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.2.8.0\lib\net462\Bonsai.Scripting.Expressions.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.2.8.0\lib\net462\Bonsai.Scripting.IronPython.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Python.0.2.1\lib\net472\Bonsai.Scripting.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.1\lib\net462\Bonsai.Vision.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.1\lib\net462\Bonsai.Vision.Design.dll"/>
-    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Modules.dll"/>
-    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.SQLite.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll"/>
-    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.AspNet.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.Metadata.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll"/>
-    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages\OpenCV.Net.3.4.2\lib\net462\OpenCV.Net.dll"/>
-    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages\OpenTK.3.1.0\lib\net20\OpenTK.dll"/>
-    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages\OxyPlot.Core.2.1.2\lib\net45\OxyPlot.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages\OxyPlot.WindowsForms.2.1.2\lib\net45\OxyPlot.WindowsForms.dll"/>
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages\pythonnet.3.0.3\lib\netstandard2.0\Python.Runtime.dll"/>
-    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll"/>
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll"/>
-    <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages\System.Linq.4.3.0\lib\net463\System.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll"/>
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.7.1\lib\net47\YamlDotNet.dll"/>
-    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages\ZedGraph.5.1.7\lib\net35-Client\ZedGraph.dll"/>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.0/lib/net472/Bonsai.ML.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.0/lib/net472/Bonsai.ML.Data.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.0/lib/net472/Bonsai.ML.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.3.0/lib/net472/Bonsai.ML.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
+    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
+    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
+    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
+    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
+    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
+    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
+    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
+    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages/System.Linq.4.3.0/lib/net463/System.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
+    <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.7.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native_uap" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native_uap" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native" platform="x86"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x64\native\vc14\bin" platform="x64"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x86\native\vc14\bin" platform="x86"/>
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>
 </PackageConfiguration>

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
@@ -1,107 +1,117 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.3"/>
-    <Package id="Bonsai.Core" version="2.8.2"/>
-    <Package id="Bonsai.Design" version="2.8.1"/>
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0"/>
-    <Package id="Bonsai.Dsp" version="2.8.0"/>
-    <Package id="Bonsai.Editor" version="2.8.2"/>
-    <Package id="Bonsai.ML" version="0.3.0"/>
-    <Package id="Bonsai.ML.Data" version="0.3.0"/>
-    <Package id="Bonsai.ML.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.Python" version="0.3.0"/>
-    <Package id="Bonsai.Scripting.Python" version="0.2.1"/>
-    <Package id="Bonsai.System" version="2.8.1"/>
-    <Package id="Bonsai.Vision" version="2.8.0"/>
-    <Package id="Bonsai.Vision.Design" version="2.8.1"/>
-    <Package id="jacobslusser.ScintillaNET" version="3.6.3"/>
-    <Package id="Markdig" version="0.18.1"/>
-    <Package id="MathNet.Numerics" version="5.0.0"/>
-    <Package id="Microsoft.CSharp" version="4.7.0"/>
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
-    <Package id="Newtonsoft.Json" version="13.0.3"/>
-    <Package id="OpenCV.Net" version="3.4.2"/>
-    <Package id="OpenTK" version="3.1.0"/>
-    <Package id="OpenTK.GLControl" version="3.1.0"/>
-    <Package id="OxyPlot.Core" version="2.1.2"/>
-    <Package id="OxyPlot.WindowsForms" version="2.1.2"/>
-    <Package id="pythonnet" version="3.0.3"/>
-    <Package id="Rx-Core" version="2.2.5"/>
-    <Package id="Rx-Interfaces" version="2.2.5"/>
-    <Package id="Rx-Linq" version="2.2.5"/>
-    <Package id="Rx-PlatformServices" version="2.2.5"/>
-    <Package id="SvgNet" version="3.3.3"/>
-    <Package id="System.Reflection.Emit" version="4.3.0"/>
-    <Package id="YamlDotNet" version="13.1.1"/>
-    <Package id="ZedGraph" version="5.1.7"/>
+    <Package id="Bonsai" version="2.8.5" />
+    <Package id="Bonsai.Core" version="2.8.5" />
+    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
+    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.ML" version="0.3.0" />
+    <Package id="Bonsai.ML.Data" version="0.3.0" />
+    <Package id="Bonsai.ML.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.Python" version="0.3.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
+    <Package id="Bonsai.System" version="2.8.1" />
+    <Package id="Bonsai.Vision" version="2.8.1" />
+    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
+    <Package id="Markdig" version="0.18.1" />
+    <Package id="MathNet.Numerics" version="5.0.0" />
+    <Package id="Microsoft.CSharp" version="4.7.0" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Newtonsoft.Json" version="13.0.3" />
+    <Package id="OpenCV.Net" version="3.4.2" />
+    <Package id="OpenTK" version="3.1.0" />
+    <Package id="OpenTK.GLControl" version="3.1.0" />
+    <Package id="OxyPlot.Core" version="2.1.2" />
+    <Package id="OxyPlot.WindowsForms" version="2.1.2" />
+    <Package id="pythonnet" version="3.0.3" />
+    <Package id="Rx-Core" version="2.2.5" />
+    <Package id="Rx-Interfaces" version="2.2.5" />
+    <Package id="Rx-Linq" version="2.2.5" />
+    <Package id="Rx-PlatformServices" version="2.2.5" />
+    <Package id="SvgNet" version="3.3.3" />
+    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="System.Memory" version="4.5.5" />
+    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Reflection.Emit" version="4.3.0" />
+    <Package id="System.Resources.Extensions" version="8.0.0" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
+    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
-    <AssemblyReference assemblyName="Bonsai"/>
-    <AssemblyReference assemblyName="Bonsai.Core"/>
-    <AssemblyReference assemblyName="Bonsai.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Design.Visualizers"/>
-    <AssemblyReference assemblyName="Bonsai.Dsp"/>
-    <AssemblyReference assemblyName="Bonsai.Editor"/>
-    <AssemblyReference assemblyName="Bonsai.ML"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Data"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Python"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Python"/>
-    <AssemblyReference assemblyName="Bonsai.System"/>
-    <AssemblyReference assemblyName="Bonsai.Vision"/>
-    <AssemblyReference assemblyName="Bonsai.Vision.Design"/>
+    <AssemblyReference assemblyName="Bonsai" />
+    <AssemblyReference assemblyName="Bonsai.Core" />
+    <AssemblyReference assemblyName="Bonsai.Design" />
+    <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
+    <AssemblyReference assemblyName="Bonsai.Dsp" />
+    <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.ML" />
+    <AssemblyReference assemblyName="Bonsai.ML.Data" />
+    <AssemblyReference assemblyName="Bonsai.ML.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Python" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
+    <AssemblyReference assemblyName="Bonsai.System" />
+    <AssemblyReference assemblyName="Bonsai.Vision" />
+    <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.3\lib\net48\Bonsai.exe"/>
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.2\lib\net462\Bonsai.Core.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.1\lib\net462\Bonsai.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.2\lib\net472\Bonsai.Editor.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages\Bonsai.ML.0.3.0\lib\net472\Bonsai.ML.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Data.0.3.0\lib\net472\Bonsai.ML.Data.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Design.0.3.0\lib\net472\Bonsai.ML.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.Design.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Python.0.3.0\lib\net472\Bonsai.ML.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Python.0.2.1\lib\net472\Bonsai.Scripting.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.0\lib\net462\Bonsai.Vision.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.1\lib\net462\Bonsai.Vision.Design.dll"/>
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll"/>
-    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll"/>
-    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages\OpenCV.Net.3.4.2\lib\net462\OpenCV.Net.dll"/>
-    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages\OpenTK.3.1.0\lib\net20\OpenTK.dll"/>
-    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages\OxyPlot.Core.2.1.2\lib\net45\OxyPlot.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages\OxyPlot.WindowsForms.2.1.2\lib\net45\OxyPlot.WindowsForms.dll"/>
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages\pythonnet.3.0.3\lib\netstandard2.0\Python.Runtime.dll"/>
-    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll"/>
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll"/>
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.1.1\lib\net47\YamlDotNet.dll"/>
-    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages\ZedGraph.5.1.7\lib\net35-Client\ZedGraph.dll"/>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.0/lib/net472/Bonsai.ML.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.0/lib/net472/Bonsai.ML.Data.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.0/lib/net472/Bonsai.ML.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.3.0/lib/net472/Bonsai.ML.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
+    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
+    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
+    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
+    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
+    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
+    <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native_uap" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native_uap" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native" platform="x86"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x64\native\vc14\bin" platform="x64"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x86\native\vc14\bin" platform="x86"/>
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>
 </PackageConfiguration>

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
@@ -1,137 +1,147 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.2"/>
-    <Package id="Bonsai.Core" version="2.8.1"/>
-    <Package id="Bonsai.Design" version="2.8.0"/>
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0"/>
-    <Package id="Bonsai.Dsp" version="2.8.0"/>
-    <Package id="Bonsai.Editor" version="2.8.1"/>
-    <Package id="Bonsai.ML" version="0.3.0"/>
-    <Package id="Bonsai.ML.Data" version="0.3.0"/>
-    <Package id="Bonsai.ML.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0"/>
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0"/>
-    <Package id="Bonsai.ML.Python" version="0.3.0"/>
-    <Package id="Bonsai.Numerics" version="0.9.0"/>
-    <Package id="Bonsai.Scripting" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0"/>
-    <Package id="Bonsai.Scripting.Python" version="0.2.1"/>
-    <Package id="Bonsai.System" version="2.8.0"/>
-    <Package id="Bonsai.Vision" version="2.8.0"/>
-    <Package id="Bonsai.Vision.Design" version="2.8.1"/>
-    <Package id="IronPython" version="2.7.5"/>
-    <Package id="IronPython.StdLib" version="2.7.5"/>
-    <Package id="jacobslusser.ScintillaNET" version="3.6.3"/>
-    <Package id="Markdig" version="0.18.1"/>
-    <Package id="MathNet.Numerics" version="5.0.0"/>
-    <Package id="Microsoft.CSharp" version="4.7.0"/>
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
-    <Package id="Newtonsoft.Json" version="13.0.3"/>
-    <Package id="OpenCV.Net" version="3.4.2"/>
-    <Package id="OpenTK" version="3.1.0"/>
-    <Package id="OpenTK.GLControl" version="3.1.0"/>
-    <Package id="OxyPlot.Core" version="2.1.2"/>
-    <Package id="OxyPlot.WindowsForms" version="2.1.2"/>
-    <Package id="pythonnet" version="3.0.3"/>
-    <Package id="Rx-Core" version="2.2.5"/>
-    <Package id="Rx-Interfaces" version="2.2.5"/>
-    <Package id="Rx-Linq" version="2.2.5"/>
-    <Package id="Rx-PlatformServices" version="2.2.5"/>
-    <Package id="SvgNet" version="3.3.3"/>
-    <Package id="System.Linq.Dynamic" version="1.0.7"/>
-    <Package id="System.Reflection.Emit" version="4.3.0"/>
-    <Package id="YamlDotNet" version="13.1.1"/>
-    <Package id="ZedGraph" version="5.1.7"/>
+    <Package id="Bonsai" version="2.8.5" />
+    <Package id="Bonsai.Core" version="2.8.5" />
+    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
+    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.ML" version="0.3.0" />
+    <Package id="Bonsai.ML.Data" version="0.3.0" />
+    <Package id="Bonsai.ML.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.3.0" />
+    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.3.0" />
+    <Package id="Bonsai.ML.Python" version="0.3.0" />
+    <Package id="Bonsai.Numerics" version="0.9.0" />
+    <Package id="Bonsai.Scripting" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
+    <Package id="Bonsai.System" version="2.8.1" />
+    <Package id="Bonsai.Vision" version="2.8.1" />
+    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="IronPython" version="2.7.5" />
+    <Package id="IronPython.StdLib" version="2.7.5" />
+    <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
+    <Package id="Markdig" version="0.18.1" />
+    <Package id="MathNet.Numerics" version="5.0.0" />
+    <Package id="Microsoft.CSharp" version="4.7.0" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Newtonsoft.Json" version="13.0.3" />
+    <Package id="OpenCV.Net" version="3.4.2" />
+    <Package id="OpenTK" version="3.1.0" />
+    <Package id="OpenTK.GLControl" version="3.1.0" />
+    <Package id="OxyPlot.Core" version="2.1.2" />
+    <Package id="OxyPlot.WindowsForms" version="2.1.2" />
+    <Package id="pythonnet" version="3.0.3" />
+    <Package id="Rx-Core" version="2.2.5" />
+    <Package id="Rx-Interfaces" version="2.2.5" />
+    <Package id="Rx-Linq" version="2.2.5" />
+    <Package id="Rx-PlatformServices" version="2.2.5" />
+    <Package id="SvgNet" version="3.3.3" />
+    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="System.Linq.Dynamic" version="1.0.7" />
+    <Package id="System.Memory" version="4.5.5" />
+    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Reflection.Emit" version="4.3.0" />
+    <Package id="System.Resources.Extensions" version="8.0.0" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
+    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
-    <AssemblyReference assemblyName="Bonsai"/>
-    <AssemblyReference assemblyName="Bonsai.Core"/>
-    <AssemblyReference assemblyName="Bonsai.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Design.Visualizers"/>
-    <AssemblyReference assemblyName="Bonsai.Dsp"/>
-    <AssemblyReference assemblyName="Bonsai.Editor"/>
-    <AssemblyReference assemblyName="Bonsai.ML"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Data"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems"/>
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design"/>
-    <AssemblyReference assemblyName="Bonsai.ML.Python"/>
-    <AssemblyReference assemblyName="Bonsai.Numerics"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design"/>
-    <AssemblyReference assemblyName="Bonsai.Scripting.Python"/>
-    <AssemblyReference assemblyName="Bonsai.System"/>
-    <AssemblyReference assemblyName="Bonsai.Vision"/>
-    <AssemblyReference assemblyName="Bonsai.Vision.Design"/>
+    <AssemblyReference assemblyName="Bonsai" />
+    <AssemblyReference assemblyName="Bonsai.Core" />
+    <AssemblyReference assemblyName="Bonsai.Design" />
+    <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
+    <AssemblyReference assemblyName="Bonsai.Dsp" />
+    <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.ML" />
+    <AssemblyReference assemblyName="Bonsai.ML.Data" />
+    <AssemblyReference assemblyName="Bonsai.ML.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
+    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Python" />
+    <AssemblyReference assemblyName="Bonsai.Numerics" />
+    <AssemblyReference assemblyName="Bonsai.Scripting" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
+    <AssemblyReference assemblyName="Bonsai.System" />
+    <AssemblyReference assemblyName="Bonsai.Vision" />
+    <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.2\lib\net48\Bonsai.exe"/>
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.1\lib\net472\Bonsai.Editor.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages\Bonsai.ML.0.3.0\lib\net472\Bonsai.ML.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Data.0.3.0\lib\net472\Bonsai.ML.Data.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Design.0.3.0\lib\net472\Bonsai.ML.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages\Bonsai.ML.LinearDynamicalSystems.Design.0.3.0\lib\net472\Bonsai.ML.LinearDynamicalSystems.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages\Bonsai.ML.Python.0.3.0\lib\net472\Bonsai.ML.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages\Bonsai.Numerics.0.9.0\lib\net462\Bonsai.Numerics.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.2.8.0\lib\net462\Bonsai.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.2.8.0\lib\net462\Bonsai.Scripting.Expressions.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.2.8.0\lib\net462\Bonsai.Scripting.IronPython.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Python.0.2.1\lib\net472\Bonsai.Scripting.Python.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.0\lib\net462\Bonsai.System.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.0\lib\net462\Bonsai.Vision.dll"/>
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.1\lib\net462\Bonsai.Vision.Design.dll"/>
-    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Modules.dll"/>
-    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.SQLite.dll"/>
-    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll"/>
-    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages\MathNet.Numerics.5.0.0\lib\net48\MathNet.Numerics.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.AspNet.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\Microsoft.Scripting.Metadata.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll"/>
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Wpf.dll"/>
-    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll"/>
-    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages\OpenCV.Net.3.4.2\lib\net462\OpenCV.Net.dll"/>
-    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages\OpenTK.3.1.0\lib\net20\OpenTK.dll"/>
-    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages\OxyPlot.Core.2.1.2\lib\net45\OxyPlot.dll"/>
-    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages\OxyPlot.WindowsForms.2.1.2\lib\net45\OxyPlot.WindowsForms.dll"/>
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages\pythonnet.3.0.3\lib\netstandard2.0\Python.Runtime.dll"/>
-    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll"/>
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll"/>
-    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll"/>
-    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll"/>
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.1.1\lib\net47\YamlDotNet.dll"/>
-    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages\ZedGraph.5.1.7\lib\net35-Client\ZedGraph.dll"/>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.0/lib/net472/Bonsai.ML.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.0/lib/net472/Bonsai.ML.Data.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.0/lib/net472/Bonsai.ML.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.3.0/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.3.0/lib/net472/Bonsai.ML.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.9.0/lib/net462/Bonsai.Numerics.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
+    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
+    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
+    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
+    <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
+    <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
+    <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
+    <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
+    <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
+    <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
+    <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-arm64\native_uap" platform="arm64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x64\native_uap" platform="x64"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native" platform="x86"/>
-    <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x64\native\vc14\bin" platform="x64"/>
-    <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x86\native\vc14\bin" platform="x86"/>
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
+    <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>
 </PackageConfiguration>


### PR DESCRIPTION
This PR updates the bootstrapper version for all examples to Bonsai 2.8.5 and normalizes the config file to the new cross-platform path format. This is to normalize all examples to the same version of Bonsai and avoid subtle issues when exporting workflow vector images.