### PR TITLE
Update examples to Bonsai 2.9.0

### DIFF
--- a/examples/HiddenMarkovModels/ExtendedModelConfiguration/.bonsai/Bonsai.config
+++ b/examples/HiddenMarkovModels/ExtendedModelConfiguration/.bonsai/Bonsai.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
     <Package id="Bonsai.ML.Data" version="0.3.1" />
     <Package id="Bonsai.ML.HiddenMarkovModels" version="0.3.1" />
@@ -12,25 +12,27 @@
     <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
     <Package id="Bonsai.Scripting.Python" version="0.2.1" />
     <Package id="Bonsai.System" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="pythonnet" version="3.0.3" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
   </Packages>
   <AssemblyReferences>
     <AssemblyReference assemblyName="Bonsai" />
@@ -46,10 +48,10 @@
     <AssemblyReference assemblyName="Bonsai.System" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.HiddenMarkovModels" processorArchitecture="MSIL" location="Packages/Bonsai.ML.HiddenMarkovModels.0.3.1/lib/net472/Bonsai.ML.HiddenMarkovModels.dll" />
@@ -57,32 +59,34 @@
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
   </LibraryFolders>
 </PackageConfiguration>

--- a/examples/HiddenMarkovModels/ExtendedModelConfiguration/.bonsai/NuGet.config
+++ b/examples/HiddenMarkovModels/ExtendedModelConfiguration/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/.bonsai/Bonsai.config
+++ b/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/.bonsai/Bonsai.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.0" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.Gui" version="0.1.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
     <Package id="Bonsai.ML.Data" version="0.3.1" />
@@ -21,11 +21,13 @@
     <Package id="Bonsai.System" version="2.8.0" />
     <Package id="Bonsai.Vision" version="2.8.0" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
@@ -37,15 +39,15 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -71,12 +73,12 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.1.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.1/lib/net472/Bonsai.ML.Data.dll" />
@@ -91,11 +93,11 @@
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.0/lib/net462/Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.0/lib/net462/Bonsai.Vision.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
@@ -104,27 +106,29 @@
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/.bonsai/NuGet.config
+++ b/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/examples/HiddenMarkovModels/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/HiddenMarkovModels/SimulatedData/.bonsai/Bonsai.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.0" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.Gui" version="0.1.0" />
     <Package id="Bonsai.Gui.ZedGraph" version="0.1.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
@@ -22,11 +22,13 @@
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.Vision" version="2.8.0" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
@@ -38,15 +40,15 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -73,12 +75,12 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.1.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.Gui.ZedGraph" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.ZedGraph.0.1.0/lib/net472/Bonsai.Gui.ZedGraph.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
@@ -94,11 +96,11 @@
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.0/lib/net462/Bonsai.Vision.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
@@ -107,27 +109,29 @@
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/examples/HiddenMarkovModels/SimulatedData/.bonsai/NuGet.config
+++ b/examples/HiddenMarkovModels/SimulatedData/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/Bonsai.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.1" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
     <Package id="Bonsai.ML.Data" version="0.3.1" />
     <Package id="Bonsai.ML.Design" version="0.3.1" />
@@ -21,13 +21,15 @@
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.Vision" version="2.8.1" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
     <Package id="IronPython.StdLib" version="2.7.5" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
@@ -39,16 +41,16 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq" version="4.3.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.7.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -74,12 +76,12 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.1/lib/net472/Bonsai.ML.Design.dll" />
@@ -98,15 +100,15 @@
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
     <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
     <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
@@ -115,28 +117,30 @@
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages/System.Linq.4.3.0/lib/net463/System.Linq.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.7.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/NuGet.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/Bonsai.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.1" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
     <Package id="Bonsai.ML.Data" version="0.3.1" />
     <Package id="Bonsai.ML.Design" version="0.3.1" />
@@ -22,13 +22,15 @@
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.Vision" version="2.8.1" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
     <Package id="IronPython.StdLib" version="2.7.5" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
@@ -40,16 +42,16 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq" version="4.3.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -76,12 +78,12 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.1/lib/net472/Bonsai.ML.Design.dll" />
@@ -101,15 +103,15 @@
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
     <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
     <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
@@ -118,28 +120,30 @@
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages/System.Linq.4.3.0/lib/net463/System.Linq.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/NuGet.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/Bonsai.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.1" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
     <Package id="Bonsai.ML.Data" version="0.3.1" />
     <Package id="Bonsai.ML.Design" version="0.3.1" />
@@ -22,13 +22,15 @@
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.Vision" version="2.8.1" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
     <Package id="IronPython.StdLib" version="2.7.5" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
@@ -40,15 +42,15 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -75,12 +77,12 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.1/lib/net472/Bonsai.ML.Design.dll" />
@@ -100,15 +102,15 @@
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
     <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
     <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
@@ -117,27 +119,29 @@
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/NuGet.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/Bonsai.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.1" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
     <Package id="Bonsai.ML.Data" version="0.3.1" />
     <Package id="Bonsai.ML.Design" version="0.3.1" />
@@ -23,13 +23,15 @@
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.Vision" version="2.8.1" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
     <Package id="IronPython.StdLib" version="2.7.5" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
@@ -41,16 +43,16 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq" version="4.3.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.7.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -78,12 +80,12 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.1/lib/net472/Bonsai.ML.Design.dll" />
@@ -104,15 +106,15 @@
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
     <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
     <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
@@ -121,28 +123,30 @@
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages/System.Linq.4.3.0/lib/net463/System.Linq.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.7.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/NuGet.config
+++ b/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/Bonsai.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.1" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
     <Package id="Bonsai.ML.Data" version="0.3.1" />
     <Package id="Bonsai.ML.Design" version="0.3.1" />
@@ -22,13 +22,15 @@
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.Vision" version="2.8.1" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
     <Package id="IronPython.StdLib" version="2.7.5" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
@@ -40,16 +42,16 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq" version="4.3.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.7.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -76,12 +78,12 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.1/lib/net472/Bonsai.ML.Design.dll" />
@@ -101,15 +103,15 @@
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
     <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
     <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
@@ -118,28 +120,30 @@
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq" processorArchitecture="MSIL" location="Packages/System.Linq.4.3.0/lib/net463/System.Linq.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.7.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/NuGet.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.1" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
     <Package id="Bonsai.ML.Data" version="0.3.1" />
     <Package id="Bonsai.ML.Design" version="0.3.1" />
@@ -17,11 +17,13 @@
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.Vision" version="2.8.1" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
@@ -33,14 +35,14 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -62,12 +64,12 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.1/lib/net472/Bonsai.ML.Design.dll" />
@@ -78,11 +80,11 @@
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
@@ -91,26 +93,28 @@
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/NuGet.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.5" />
-    <Package id="Bonsai.Core" version="2.8.5" />
-    <Package id="Bonsai.Design" version="2.8.5" />
+    <Package id="Bonsai" version="2.9.0" />
+    <Package id="Bonsai.Core" version="2.9.0" />
+    <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.1" />
-    <Package id="Bonsai.Editor" version="2.8.5" />
+    <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.3.1" />
     <Package id="Bonsai.ML.Data" version="0.3.1" />
     <Package id="Bonsai.ML.Design" version="0.3.1" />
@@ -23,13 +23,15 @@
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.Vision" version="2.8.1" />
     <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="DockPanelSuite" version="3.1.1" />
+    <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
     <Package id="IronPython.StdLib" version="2.7.5" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
-    <Package id="Markdig" version="0.18.1" />
+    <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
     <Package id="Microsoft.CSharp" version="4.7.0" />
-    <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
+    <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
@@ -41,15 +43,15 @@
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
-    <Package id="SvgNet" version="3.3.3" />
-    <Package id="System.Buffers" version="4.5.1" />
+    <Package id="SvgNet" version="3.5.0" />
+    <Package id="System.Buffers" version="4.6.0" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
-    <Package id="System.Memory" version="4.5.5" />
-    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Memory" version="4.6.0" />
+    <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Reflection.Emit" version="4.3.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
-    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
-    <Package id="YamlDotNet" version="13.1.1" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" />
+    <Package id="YamlDotNet" version="16.3.0" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
@@ -77,12 +79,12 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.8.5/lib/net48/Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.8.5/lib/net462/Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.8.5/lib/net462/Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.8.5/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.3.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.3.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.3.1/lib/net472/Bonsai.ML.Design.dll" />
@@ -103,15 +105,15 @@
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
     <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
-    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.18.1/lib/net40/Markdig.dll" />
+    <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
     <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
     <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Core.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.WinForms.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.1823.32/lib/net45/Microsoft.Web.WebView2.Wpf.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
+    <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages/OpenCV.Net.3.4.2/lib/net462/OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages/OpenTK.3.1.0/lib/net20/OpenTK.dll" />
@@ -120,27 +122,29 @@
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
     <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
-    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.3.3/lib/net462/SVG.dll" />
-    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.5.1/lib/net461/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.1.0.7/lib/net40/System.Linq.Dynamic.dll" />
-    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.5.5/lib/net461/System.Memory.dll" />
-    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.5.0/lib/net46/System.Numerics.Vectors.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages/Rx-Interfaces.2.2.5/lib/net45/System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages/Rx-Linq.2.2.5/lib/net45/System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages/Rx-PlatformServices.2.2.5/lib/net45/System.Reactive.PlatformServices.dll" />
     <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages/System.Resources.Extensions.8.0.0/lib/net462/System.Resources.Extensions.dll" />
-    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.4.5.3/lib/net461/System.Runtime.CompilerServices.Unsafe.dll" />
-    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.13.1.1/lib/net47/YamlDotNet.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages/System.Runtime.CompilerServices.Unsafe.6.1.0/lib/net462/System.Runtime.CompilerServices.Unsafe.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking" processorArchitecture="MSIL" location="Packages/DockPanelSuite.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.dll" />
+    <AssemblyLocation assemblyName="WeifenLuo.WinFormsUI.Docking.ThemeVS2015" processorArchitecture="MSIL" location="Packages/DockPanelSuite.ThemeVS2015.3.1.1/lib/net40/WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
+    <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages/YamlDotNet.16.3.0/lib/net47/YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages/ZedGraph.5.1.7/lib/net35-Client/ZedGraph.dll" />
   </AssemblyLocations>
   <LibraryFolders>
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-arm64/native_uap" platform="arm64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x64/native_uap" platform="x64" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native" platform="x86" />
-    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.1823.32/runtimes/win-x86/native_uap" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-arm64/native_uap" platform="arm64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x64/native_uap" platform="x64" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native" platform="x86" />
+    <LibraryFolder path="Packages/Microsoft.Web.WebView2.1.0.2792.45/runtimes/win-x86/native_uap" platform="x86" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x64/native/vc14/bin" platform="x64" />
     <LibraryFolder path="Packages/OpenCV.Net.3.4.2/runtimes/win-x86/native/vc14/bin" platform="x86" />
   </LibraryFolders>

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/NuGet.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/NuGet.config
@@ -2,7 +2,5 @@
 <configuration>
   <packageSources>
     <add key="Gallery" value="Gallery" />
-    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
-    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Bonsai 2.9.0 is required to unblock https://github.com/bonsai-rx/machinelearning/pull/56

This PR only updates examples which existed prior to https://github.com/bonsai-rx/machinelearning-examples/pull/15 and https://github.com/bonsai-rx/machinelearning-examples/pull/17

As such, it is intentional that it is based before those PRs, this is required to unblock https://github.com/bonsai-rx/machinelearning/pull/56 because it will point to the commit introduced by this branch.

This PR *must* be merged with a merge commit.

The examples repo has a chicken and egg problem with regards to the versions of Bonsai.ML packages it uses. This will take a wider discussion to resolve. Nick and I discussed some ideas, but the ideal solution could require changes to Bonsai.

In the short term we will continue with the previous strategy of waiting to bump the submodule until after Bonsai.ML is updated on NuGet.org.