### PR TITLE
Ignore `Settings` folder in local Bonsai environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ obj
 .venv
 Packages
 Gallery
+Settings
 *.csv
 *.bin
 __pycache__


### PR DESCRIPTION
This PR adds the `Settings` folder to the `.gitignore` to ensure that git correctly ignores local cache of settings files in Bonsai example environments.