### PR TITLE
Update Bonsai Package Dependency Versions to Latest

### DIFF
--- a/examples/HiddenMarkovModels/ExtendedModelConfiguration/.bonsai/Bonsai.config
+++ b/examples/HiddenMarkovModels/ExtendedModelConfiguration/.bonsai/Bonsai.config
@@ -9,9 +9,9 @@
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.HiddenMarkovModels" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
@@ -19,7 +19,7 @@
     <Package id="Microsoft.CSharp" version="4.7.0" />
     <Package id="Microsoft.Web.WebView2" version="1.0.2792.45" />
     <Package id="Newtonsoft.Json" version="13.0.3" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -56,15 +56,15 @@
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.HiddenMarkovModels" processorArchitecture="MSIL" location="Packages/Bonsai.ML.HiddenMarkovModels.0.4.1/lib/net472/Bonsai.ML.HiddenMarkovModels.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
     <AssemblyLocation assemblyName="Newtonsoft.Json" processorArchitecture="MSIL" location="Packages/Newtonsoft.Json.13.0.3/lib/net45/Newtonsoft.Json.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/.bonsai/Bonsai.config
+++ b/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/.bonsai/Bonsai.config
@@ -4,10 +4,10 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.0" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
-    <Package id="Bonsai.Gui" version="0.1.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
@@ -16,11 +16,11 @@
     <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.0" />
-    <Package id="Bonsai.Vision" version="2.8.0" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
@@ -34,7 +34,7 @@
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="OxyPlot.Core" version="2.1.2" />
     <Package id="OxyPlot.WindowsForms" version="2.1.2" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -76,10 +76,10 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.1.0/lib/net472/Bonsai.Gui.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
@@ -88,11 +88,11 @@
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.0/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.0/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
@@ -104,7 +104,7 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/HiddenMarkovModels/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/HiddenMarkovModels/SimulatedData/.bonsai/Bonsai.config
@@ -4,11 +4,11 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.0" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
-    <Package id="Bonsai.Gui" version="0.1.0" />
-    <Package id="Bonsai.Gui.ZedGraph" version="0.1.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
+    <Package id="Bonsai.Gui.ZedGraph" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
@@ -16,12 +16,12 @@
     <Package id="Bonsai.ML.HiddenMarkovModels.Design" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Numerics" version="0.9.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.0" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Numerics" version="0.10.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
@@ -35,7 +35,7 @@
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="OxyPlot.Core" version="2.1.2" />
     <Package id="OxyPlot.WindowsForms" version="2.1.2" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -78,11 +78,11 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.1.0/lib/net472/Bonsai.Gui.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui.ZedGraph" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.ZedGraph.0.1.0/lib/net472/Bonsai.Gui.ZedGraph.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui.ZedGraph" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.ZedGraph.0.2.0/lib/net472/Bonsai.Gui.ZedGraph.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
@@ -90,12 +90,12 @@
     <AssemblyLocation assemblyName="Bonsai.ML.HiddenMarkovModels.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.HiddenMarkovModels.Design.0.4.1/lib/net472/Bonsai.ML.HiddenMarkovModels.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.9.0/lib/net462/Bonsai.Numerics.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.0/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.10.0/lib/net462/Bonsai.Numerics.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
@@ -107,7 +107,7 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/Bonsai.config
@@ -4,23 +4,24 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.9.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
@@ -36,7 +37,7 @@
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="OxyPlot.Core" version="2.1.2" />
     <Package id="OxyPlot.WindowsForms" version="2.1.2" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -60,6 +61,7 @@
     <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
     <AssemblyReference assemblyName="Bonsai.Dsp" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.Gui" />
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
@@ -79,23 +81,24 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.9.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.9.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
@@ -115,7 +118,7 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/ForagingMouse.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/ForagingMouse.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.9.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -7,7 +7,7 @@
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:drw="clr-namespace:Bonsai.Vision.Drawing;assembly=Bonsai.Vision"
                  xmlns:ipy="clr-namespace:Bonsai.Scripting.IronPython;assembly=Bonsai.Scripting.IronPython"
-                 xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
+                 xmlns:gui="clr-namespace:Bonsai.Gui;assembly=Bonsai.Gui"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -690,13 +690,15 @@ def process(value):
         </Workflow>
       </Expression>
       <Expression xsi:type="VisualizerMapping" />
-      <Expression xsi:type="viz:TableLayoutPanelBuilder">
-        <viz:Name>MouseKinematicsVisualizer</viz:Name>
-        <viz:ColumnCount>2</viz:ColumnCount>
-        <viz:RowCount>1</viz:RowCount>
-        <viz:ColumnStyles />
-        <viz:RowStyles />
-        <viz:CellSpans />
+      <Expression xsi:type="gui:TableLayoutPanelBuilder">
+        <gui:Name>MouseKinematicsVisualizer</gui:Name>
+        <gui:Enabled>true</gui:Enabled>
+        <gui:Visible>true</gui:Visible>
+        <gui:ColumnCount>2</gui:ColumnCount>
+        <gui:RowCount>1</gui:RowCount>
+        <gui:ColumnStyles />
+        <gui:RowStyles />
+        <gui:CellSpans />
       </Expression>
     </Nodes>
     <Edges>

--- a/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/Bonsai.config
@@ -4,28 +4,24 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Scripting" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
-    <Package id="IronPython" version="2.7.5" />
-    <Package id="IronPython.StdLib" version="2.7.5" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
     <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
@@ -37,7 +33,7 @@
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="OxyPlot.Core" version="2.1.2" />
     <Package id="OxyPlot.WindowsForms" version="2.1.2" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -61,17 +57,15 @@
     <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
     <AssemblyReference assemblyName="Bonsai.Dsp" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.Gui" />
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
     <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
-    <AssemblyReference assemblyName="Bonsai.Scripting" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
     <AssemblyReference assemblyName="Bonsai.System" />
     <AssemblyReference assemblyName="Bonsai.Vision" />
@@ -81,34 +75,24 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
-    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
-    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
-    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
-    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
@@ -118,7 +102,7 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/ForecastingForagingMouse.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/ForecastingForagingMouse.bonsai
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.9.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
-                 xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
+                 xmlns:gui="clr-namespace:Bonsai.Gui;assembly=Bonsai.Gui"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -434,12 +434,14 @@
               <Name>Image</Name>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
-            <Expression xsi:type="viz:TableLayoutPanelBuilder">
-              <viz:ColumnCount>2</viz:ColumnCount>
-              <viz:RowCount>1</viz:RowCount>
-              <viz:ColumnStyles />
-              <viz:RowStyles />
-              <viz:CellSpans />
+            <Expression xsi:type="gui:TableLayoutPanelBuilder">
+              <gui:Enabled>true</gui:Enabled>
+              <gui:Visible>true</gui:Visible>
+              <gui:ColumnCount>2</gui:ColumnCount>
+              <gui:RowCount>1</gui:RowCount>
+              <gui:ColumnStyles />
+              <gui:RowStyles />
+              <gui:CellSpans />
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
           </Nodes>

--- a/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/Bonsai.config
@@ -4,24 +4,24 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Scripting" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.9.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
@@ -37,7 +37,7 @@
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="OxyPlot.Core" version="2.1.2" />
     <Package id="OxyPlot.WindowsForms" version="2.1.2" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -60,13 +60,13 @@
     <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
     <AssemblyReference assemblyName="Bonsai.Dsp" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.Gui" />
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
     <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
-    <AssemblyReference assemblyName="Bonsai.Scripting" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
     <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
@@ -80,24 +80,24 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.9.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.9.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
@@ -117,7 +117,7 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/ModelOptimizationForagingMouse.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/ModelOptimizationForagingMouse.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.9.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -7,7 +7,7 @@
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:drw="clr-namespace:Bonsai.Vision.Drawing;assembly=Bonsai.Vision"
                  xmlns:ipy="clr-namespace:Bonsai.Scripting.IronPython;assembly=Bonsai.Scripting.IronPython"
-                 xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
+                 xmlns:gui="clr-namespace:Bonsai.Gui;assembly=Bonsai.Gui"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -388,7 +388,7 @@
         <BatchSize>200</BatchSize>
         <Name>model</Name>
         <sigma_a>true</sigma_a>
-        <sigma_x_x002C__x0020_sigma_y>true</sigma_x_x002C__x0020_sigma_y>
+        <sigma_xy>true</sigma_xy>
         <m0>true</m0>
         <sqrt_diag_V0_value>true</sqrt_diag_V0_value>
         <NumIterations>50</NumIterations>
@@ -709,13 +709,15 @@ def process(value):
         </Workflow>
       </Expression>
       <Expression xsi:type="VisualizerMapping" />
-      <Expression xsi:type="viz:TableLayoutPanelBuilder">
-        <viz:Name>MouseKinematicsVisualizer</viz:Name>
-        <viz:ColumnCount>2</viz:ColumnCount>
-        <viz:RowCount>1</viz:RowCount>
-        <viz:ColumnStyles />
-        <viz:RowStyles />
-        <viz:CellSpans />
+      <Expression xsi:type="gui:TableLayoutPanelBuilder">
+        <gui:Name>MouseKinematicsVisualizer</gui:Name>
+        <gui:Enabled>true</gui:Enabled>
+        <gui:Visible>true</gui:Visible>
+        <gui:ColumnCount>2</gui:ColumnCount>
+        <gui:RowCount>1</gui:RowCount>
+        <gui:ColumnStyles />
+        <gui:RowStyles />
+        <gui:CellSpans />
       </Expression>
     </Nodes>
     <Edges>

--- a/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/Bonsai.config
@@ -4,25 +4,25 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Numerics" version="0.9.0" />
-    <Package id="Bonsai.Scripting" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Numerics" version="0.10.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.9.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
@@ -38,7 +38,7 @@
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="OxyPlot.Core" version="2.1.2" />
     <Package id="OxyPlot.WindowsForms" version="2.1.2" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -62,6 +62,7 @@
     <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
     <AssemblyReference assemblyName="Bonsai.Dsp" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.Gui" />
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
@@ -69,7 +70,6 @@
     <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Numerics" />
-    <AssemblyReference assemblyName="Bonsai.Scripting" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
     <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
@@ -83,25 +83,25 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.9.0/lib/net462/Bonsai.Numerics.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.10.0/lib/net462/Bonsai.Numerics.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.9.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.9.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
@@ -121,7 +121,7 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/SimulatedData/Simulation.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/SimulatedData/Simulation.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.9.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
@@ -9,7 +9,7 @@
                  xmlns:drw="clr-namespace:Bonsai.Vision.Drawing;assembly=Bonsai.Vision"
                  xmlns:ipy="clr-namespace:Bonsai.Scripting.IronPython;assembly=Bonsai.Scripting.IronPython"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
-                 xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
+                 xmlns:gui="clr-namespace:Bonsai.Gui;assembly=Bonsai.Gui"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -577,18 +577,15 @@ def process(value):
         </Workflow>
       </Expression>
       <Expression xsi:type="VisualizerMapping" />
-      <Expression xsi:type="viz:TableLayoutPanelBuilder">
-        <viz:Name>SimulatedDataVisualizer</viz:Name>
-        <viz:ColumnCount>2</viz:ColumnCount>
-        <viz:RowCount>1</viz:RowCount>
-        <viz:ColumnStyles />
-        <viz:RowStyles>
-          <viz:RowStyle>
-            <viz:SizeType>Absolute</viz:SizeType>
-            <viz:Height>0</viz:Height>
-          </viz:RowStyle>
-        </viz:RowStyles>
-        <viz:CellSpans />
+      <Expression xsi:type="gui:TableLayoutPanelBuilder">
+        <gui:Name>SimulatedDataVisualizer</gui:Name>
+        <gui:Enabled>true</gui:Enabled>
+        <gui:Visible>true</gui:Visible>
+        <gui:ColumnCount>2</gui:ColumnCount>
+        <gui:RowCount>1</gui:RowCount>
+        <gui:ColumnStyles />
+        <gui:RowStyles />
+        <gui:CellSpans />
       </Expression>
     </Nodes>
     <Edges>

--- a/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/Bonsai.config
@@ -4,24 +4,24 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Scripting" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.IronPython" version="2.9.0" />
+    <Package id="Bonsai.Scripting.IronPython.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="IronPython" version="2.7.5" />
@@ -37,7 +37,7 @@
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="OxyPlot.Core" version="2.1.2" />
     <Package id="OxyPlot.WindowsForms" version="2.1.2" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -61,13 +61,13 @@
     <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
     <AssemblyReference assemblyName="Bonsai.Dsp" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.Gui" />
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
     <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
-    <AssemblyReference assemblyName="Bonsai.Scripting" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
     <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
@@ -81,24 +81,24 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.9.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.9.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
     <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
     <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
@@ -118,7 +118,7 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/ZebrafishTracking.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/ZebrafishTracking.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.9.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -7,7 +7,7 @@
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:drw="clr-namespace:Bonsai.Vision.Drawing;assembly=Bonsai.Vision"
                  xmlns:ipy="clr-namespace:Bonsai.Scripting.IronPython;assembly=Bonsai.Scripting.IronPython"
-                 xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
+                 xmlns:gui="clr-namespace:Bonsai.Gui;assembly=Bonsai.Gui"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -472,13 +472,15 @@ def process(value):
         </Workflow>
       </Expression>
       <Expression xsi:type="VisualizerMapping" />
-      <Expression xsi:type="viz:TableLayoutPanelBuilder">
-        <viz:Name>ZebrafishKinematicsVisualizer</viz:Name>
-        <viz:ColumnCount>2</viz:ColumnCount>
-        <viz:RowCount>1</viz:RowCount>
-        <viz:ColumnStyles />
-        <viz:RowStyles />
-        <viz:CellSpans />
+      <Expression xsi:type="gui:TableLayoutPanelBuilder">
+        <gui:Name>ZebrafishKinematicsVisualizer</gui:Name>
+        <gui:Enabled>true</gui:Enabled>
+        <gui:Visible>true</gui:Visible>
+        <gui:ColumnCount>2</gui:ColumnCount>
+        <gui:RowCount>1</gui:RowCount>
+        <gui:ColumnStyles />
+        <gui:RowStyles />
+        <gui:CellSpans />
       </Expression>
     </Nodes>
     <Edges>

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
@@ -4,8 +4,8 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
@@ -13,10 +13,10 @@
     <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
@@ -30,7 +30,7 @@
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="OxyPlot.Core" version="2.1.2" />
     <Package id="OxyPlot.WindowsForms" version="2.1.2" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -67,8 +67,8 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
@@ -76,10 +76,10 @@
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
@@ -91,7 +91,7 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
@@ -4,8 +4,8 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
@@ -13,20 +13,15 @@
     <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
     <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
-    <Package id="Bonsai.Numerics" version="0.9.0" />
-    <Package id="Bonsai.Scripting" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython" version="2.8.0" />
-    <Package id="Bonsai.Scripting.IronPython.Design" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Python" version="0.2.1" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Numerics" version="0.10.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Python" version="0.3.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
-    <Package id="IronPython" version="2.7.5" />
-    <Package id="IronPython.StdLib" version="2.7.5" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
     <Package id="Markdig" version="0.41.1" />
     <Package id="MathNet.Numerics" version="5.0.0" />
@@ -38,7 +33,7 @@
     <Package id="OpenTK.GLControl" version="3.1.0" />
     <Package id="OxyPlot.Core" version="2.1.2" />
     <Package id="OxyPlot.WindowsForms" version="2.1.2" />
-    <Package id="pythonnet" version="3.0.3" />
+    <Package id="pythonnet" version="3.0.5" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -68,11 +63,8 @@
     <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Numerics" />
-    <AssemblyReference assemblyName="Bonsai.Scripting" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
-    <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
     <AssemblyReference assemblyName="Bonsai.System" />
     <AssemblyReference assemblyName="Bonsai.Vision" />
@@ -82,8 +74,8 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
@@ -91,26 +83,15 @@
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.9.0/lib/net462/Bonsai.Numerics.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.2.8.0/lib/net462/Bonsai.Scripting.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.2.8.0/lib/net462/Bonsai.Scripting.IronPython.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.IronPython.Design.2.8.0/lib/net462/Bonsai.Scripting.IronPython.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.2.1/lib/net472/Bonsai.Scripting.Python.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
-    <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.dll" />
-    <AssemblyLocation assemblyName="IronPython.Modules" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Modules.dll" />
-    <AssemblyLocation assemblyName="IronPython.SQLite" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.SQLite.dll" />
-    <AssemblyLocation assemblyName="IronPython.Wpf" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/IronPython.Wpf.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.10.0/lib/net462/Bonsai.Numerics.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="MathNet.Numerics" processorArchitecture="MSIL" location="Packages/MathNet.Numerics.5.0.0/lib/net48/MathNet.Numerics.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Dynamic" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Dynamic.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Scripting" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Scripting.AspNet" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.AspNet.dll" />
-    <AssemblyLocation assemblyName="Microsoft.Scripting.Metadata" processorArchitecture="MSIL" location="Packages/IronPython.2.7.5/lib/Net45/Microsoft.Scripting.Metadata.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.WinForms.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Wpf" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Wpf.dll" />
@@ -120,7 +101,7 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages/OpenTK.GLControl.3.1.0/lib/net20/OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="OxyPlot" processorArchitecture="MSIL" location="Packages/OxyPlot.Core.2.1.2/lib/net45/OxyPlot.dll" />
     <AssemblyLocation assemblyName="OxyPlot.WindowsForms" processorArchitecture="MSIL" location="Packages/OxyPlot.WindowsForms.2.1.2/lib/net45/OxyPlot.WindowsForms.dll" />
-    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.3/lib/netstandard2.0/Python.Runtime.dll" />
+    <AssemblyLocation assemblyName="Python.Runtime" processorArchitecture="MSIL" location="Packages/pythonnet.3.0.5/lib/netstandard2.0/Python.Runtime.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/Simulation.bonsai
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/Simulation.bonsai
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.9.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
                  xmlns:num="clr-namespace:Bonsai.Numerics;assembly=Bonsai.Numerics"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:p1="clr-namespace:Bonsai.Numerics.Distributions;assembly=Bonsai.Numerics"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
-                 xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -235,24 +234,12 @@
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Observation</Name>
       </Expression>
-      <Expression xsi:type="SubscribeSubject">
-        <Name>XYData</Name>
-      </Expression>
-      <Expression xsi:type="viz:LineGraphBuilder">
-        <viz:SymbolType>Circle</viz:SymbolType>
-        <viz:LineWidth>0</viz:LineWidth>
-        <viz:Capacity xsi:nil="true" />
-        <viz:XMin xsi:nil="true" />
-        <viz:XMax xsi:nil="true" />
-        <viz:YMin xsi:nil="true" />
-        <viz:YMax xsi:nil="true" />
-      </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.CreateKFModel.bonsai">
-        <LikelihoodPrecisionCoef>25</LikelihoodPrecisionCoef>
-        <PriorPrecisionCoef>2</PriorPrecisionCoef>
+        <LikelihoodPrecisionCoefficient>25</LikelihoodPrecisionCoefficient>
+        <PriorPrecisionCoefficient>2</PriorPrecisionCoefficient>
         <NumFeatures>2</NumFeatures>
         <Name>model</Name>
       </Expression>
@@ -275,10 +262,10 @@
         <Name>model</Name>
         <X0>-1</X0>
         <X1>1</X1>
-        <Xsteps>100</Xsteps>
+        <XSteps>100</XSteps>
         <Y0>-1</Y0>
         <Y1>1</Y1>
-        <Ysteps>100</Ysteps>
+        <YSteps>100</YSteps>
       </Expression>
     </Nodes>
     <Edges>
@@ -287,12 +274,11 @@
       <Edge From="5" To="6" Label="Source1" />
       <Edge From="6" To="7" Label="Source1" />
       <Edge From="8" To="9" Label="Source1" />
-      <Edge From="10" To="11" Label="Source1" />
-      <Edge From="11" To="12" Label="Source1" />
-      <Edge From="13" To="15" Label="Source1" />
-      <Edge From="14" To="15" Label="Source2" />
-      <Edge From="15" To="16" Label="Source1" />
-      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="11" To="13" Label="Source1" />
+      <Edge From="12" To="13" Label="Source2" />
+      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="14" To="15" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/examples/PointProcessDecoder/ClassifyPositionFromHippocampusSortedUnits/.bonsai/Bonsai.config
+++ b/examples/PointProcessDecoder/ClassifyPositionFromHippocampusSortedUnits/.bonsai/Bonsai.config
@@ -4,23 +4,23 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.0" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
-    <Package id="Bonsai.Gui" version="0.1.0" />
-    <Package id="Bonsai.Gui.ZedGraph" version="0.1.0" />
-    <Package id="Bonsai.ML" version="0.4.0" />
-    <Package id="Bonsai.ML.Data" version="0.4.0" />
-    <Package id="Bonsai.ML.Design" version="0.4.0" />
-    <Package id="Bonsai.ML.PointProcessDecoder" version="0.4.0" />
-    <Package id="Bonsai.ML.PointProcessDecoder.Design" version="0.4.0" />
-    <Package id="Bonsai.ML.Torch" version="0.4.0" />
-    <Package id="Bonsai.ML.Torch-cpu" version="0.4.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.System" version="2.8.0" />
-    <Package id="Bonsai.Vision" version="2.8.0" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
+    <Package id="Bonsai.Gui.ZedGraph" version="0.2.0" />
+    <Package id="Bonsai.ML" version="0.4.1" />
+    <Package id="Bonsai.ML.Data" version="0.4.1" />
+    <Package id="Bonsai.ML.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.PointProcessDecoder" version="0.4.1" />
+    <Package id="Bonsai.ML.PointProcessDecoder.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Torch" version="0.4.1" />
+    <Package id="Bonsai.ML.Torch-cpu" version="0.4.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="Google.Protobuf" version="3.21.9" />
@@ -87,22 +87,22 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.1.0/lib/net472/Bonsai.Gui.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui.ZedGraph" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.ZedGraph.0.1.0/lib/net472/Bonsai.Gui.ZedGraph.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.0/lib/net472/Bonsai.ML.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.0/lib/net472/Bonsai.ML.Data.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.0/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.0.4.0/lib/net472/Bonsai.ML.PointProcessDecoder.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.Design.0.4.0/lib/net472/Bonsai.ML.PointProcessDecoder.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.0/lib/net472/Bonsai.ML.Torch.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.0/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.0/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui.ZedGraph" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.ZedGraph.0.2.0/lib/net472/Bonsai.Gui.ZedGraph.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.0.4.1/lib/net472/Bonsai.ML.PointProcessDecoder.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.Design.0.4.1/lib/net472/Bonsai.ML.PointProcessDecoder.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.1/lib/net472/Bonsai.ML.Torch.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Google.Protobuf" processorArchitecture="MSIL" location="Packages/Google.Protobuf.3.21.9/lib/net45/Google.Protobuf.dll" />
     <AssemblyLocation assemblyName="ICSharpCode.SharpZipLib" processorArchitecture="MSIL" location="Packages/SharpZipLib.1.4.0/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />

--- a/examples/PointProcessDecoder/DecodePositionFromHippocampusClusterless/.bonsai/Bonsai.config
+++ b/examples/PointProcessDecoder/DecodePositionFromHippocampusClusterless/.bonsai/Bonsai.config
@@ -4,20 +4,20 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
-    <Package id="Bonsai.ML" version="0.4.0" />
-    <Package id="Bonsai.ML.Data" version="0.4.0" />
-    <Package id="Bonsai.ML.Design" version="0.4.0" />
-    <Package id="Bonsai.ML.PointProcessDecoder" version="0.4.0" />
-    <Package id="Bonsai.ML.PointProcessDecoder.Design" version="0.4.0" />
-    <Package id="Bonsai.ML.Torch" version="0.4.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.ML" version="0.4.1" />
+    <Package id="Bonsai.ML.Data" version="0.4.1" />
+    <Package id="Bonsai.ML.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.PointProcessDecoder" version="0.4.1" />
+    <Package id="Bonsai.ML.PointProcessDecoder.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Torch" version="0.4.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="Google.Protobuf" version="3.21.9" />
@@ -82,20 +82,20 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.0/lib/net472/Bonsai.ML.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.0/lib/net472/Bonsai.ML.Data.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.0/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.0.4.0/lib/net472/Bonsai.ML.PointProcessDecoder.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.Design.0.4.0/lib/net472/Bonsai.ML.PointProcessDecoder.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.0/lib/net472/Bonsai.ML.Torch.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.0.4.1/lib/net472/Bonsai.ML.PointProcessDecoder.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.Design.0.4.1/lib/net472/Bonsai.ML.PointProcessDecoder.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.1/lib/net472/Bonsai.ML.Torch.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Google.Protobuf" processorArchitecture="MSIL" location="Packages/Google.Protobuf.3.21.9/lib/net45/Google.Protobuf.dll" />
     <AssemblyLocation assemblyName="ICSharpCode.SharpZipLib" processorArchitecture="MSIL" location="Packages/SharpZipLib.1.4.0/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />

--- a/examples/PointProcessDecoder/DecodePositionFromHippocampusSortedUnits/.bonsai/Bonsai.config
+++ b/examples/PointProcessDecoder/DecodePositionFromHippocampusSortedUnits/.bonsai/Bonsai.config
@@ -4,8 +4,8 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.1" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
@@ -13,11 +13,11 @@
     <Package id="Bonsai.ML.PointProcessDecoder" version="0.4.1" />
     <Package id="Bonsai.ML.PointProcessDecoder.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Torch" version="0.4.1" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="Google.Protobuf" version="3.21.9" />
@@ -82,8 +82,8 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.1/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
@@ -91,11 +91,11 @@
     <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.0.4.1/lib/net472/Bonsai.ML.PointProcessDecoder.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.Design.0.4.1/lib/net472/Bonsai.ML.PointProcessDecoder.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.1/lib/net472/Bonsai.ML.Torch.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Google.Protobuf" processorArchitecture="MSIL" location="Packages/Google.Protobuf.3.21.9/lib/net45/Google.Protobuf.dll" />
     <AssemblyLocation assemblyName="ICSharpCode.SharpZipLib" processorArchitecture="MSIL" location="Packages/SharpZipLib.1.4.0/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />

--- a/examples/PointProcessDecoder/DecodePositionFromStriatumSortedUnits/.bonsai/Bonsai.config
+++ b/examples/PointProcessDecoder/DecodePositionFromStriatumSortedUnits/.bonsai/Bonsai.config
@@ -4,22 +4,22 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.0" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
-    <Package id="Bonsai.Gui" version="0.1.0" />
-    <Package id="Bonsai.Gui.ZedGraph" version="0.1.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
+    <Package id="Bonsai.Gui.ZedGraph" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
     <Package id="Bonsai.ML.PointProcessDecoder" version="0.4.1" />
     <Package id="Bonsai.ML.PointProcessDecoder.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Torch" version="0.4.1" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.System" version="2.8.0" />
-    <Package id="Bonsai.Vision" version="2.8.0" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="Google.Protobuf" version="3.21.9" />
@@ -86,22 +86,22 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.1.0/lib/net472/Bonsai.Gui.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui.ZedGraph" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.ZedGraph.0.1.0/lib/net472/Bonsai.Gui.ZedGraph.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui.ZedGraph" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.ZedGraph.0.2.0/lib/net472/Bonsai.Gui.ZedGraph.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.0.4.1/lib/net472/Bonsai.ML.PointProcessDecoder.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.PointProcessDecoder.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.PointProcessDecoder.Design.0.4.1/lib/net472/Bonsai.ML.PointProcessDecoder.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.1/lib/net472/Bonsai.ML.Torch.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.0/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.0/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Google.Protobuf" processorArchitecture="MSIL" location="Packages/Google.Protobuf.3.21.9/lib/net45/Google.Protobuf.dll" />
     <AssemblyLocation assemblyName="ICSharpCode.SharpZipLib" processorArchitecture="MSIL" location="Packages/SharpZipLib.1.4.0/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />

--- a/examples/Torch/LinearRegression/.bonsai/Bonsai.config
+++ b/examples/Torch/LinearRegression/.bonsai/Bonsai.config
@@ -5,15 +5,15 @@
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
-    <Package id="Bonsai.Gui" version="0.1.0" />
-    <Package id="Bonsai.Gui.ZedGraph" version="0.1.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
+    <Package id="Bonsai.Gui.ZedGraph" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Torch" version="0.4.1" />
     <Package id="Bonsai.ML.Torch-cpu" version="0.4.1" />
-    <Package id="Bonsai.Numerics" version="0.9.0" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
+    <Package id="Bonsai.Numerics" version="0.10.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="Google.Protobuf" version="3.21.9" />
@@ -69,14 +69,14 @@
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.1.0/lib/net472/Bonsai.Gui.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui.ZedGraph" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.ZedGraph.0.1.0/lib/net472/Bonsai.Gui.ZedGraph.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui.ZedGraph" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.ZedGraph.0.2.0/lib/net472/Bonsai.Gui.ZedGraph.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.1/lib/net472/Bonsai.ML.Torch.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.9.0/lib/net462/Bonsai.Numerics.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.10.0/lib/net462/Bonsai.Numerics.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
     <AssemblyLocation assemblyName="Google.Protobuf" processorArchitecture="MSIL" location="Packages/Google.Protobuf.3.21.9/lib/net45/Google.Protobuf.dll" />
     <AssemblyLocation assemblyName="ICSharpCode.SharpZipLib" processorArchitecture="MSIL" location="Packages/SharpZipLib.1.4.0/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />

--- a/examples/Torch/LinearRegression/Simulation.bonsai
+++ b/examples/Torch/LinearRegression/Simulation.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.5"
+<WorkflowBuilder Version="2.9.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:num="clr-namespace:Bonsai.Numerics;assembly=Bonsai.Numerics"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"

--- a/examples/Torch/NeuralNetsPretrainedModel/.bonsai/Bonsai.config
+++ b/examples/Torch/NeuralNetsPretrainedModel/.bonsai/Bonsai.config
@@ -4,19 +4,19 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.0" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
-    <Package id="Bonsai.Gui" version="0.1.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Torch" version="0.4.1" />
     <Package id="Bonsai.ML.Torch-cpu" version="0.4.1" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="Google.Protobuf" version="3.21.9" />
@@ -75,18 +75,18 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.1.0/lib/net472/Bonsai.Gui.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.1/lib/net472/Bonsai.ML.Torch.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Google.Protobuf" processorArchitecture="MSIL" location="Packages/Google.Protobuf.3.21.9/lib/net45/Google.Protobuf.dll" />
     <AssemblyLocation assemblyName="ICSharpCode.SharpZipLib" processorArchitecture="MSIL" location="Packages/SharpZipLib.1.4.0/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />

--- a/examples/Torch/NeuralNetsTorchHub/.bonsai/Bonsai.config
+++ b/examples/Torch/NeuralNetsTorchHub/.bonsai/Bonsai.config
@@ -4,18 +4,18 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.0" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Torch" version="0.4.1" />
     <Package id="Bonsai.ML.Torch-cpu" version="0.4.1" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.System" version="2.8.0" />
-    <Package id="Bonsai.Vision" version="2.8.0" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="Google.Protobuf" version="3.21.9" />
@@ -73,17 +73,17 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.1/lib/net472/Bonsai.ML.Torch.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.0/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.0/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Google.Protobuf" processorArchitecture="MSIL" location="Packages/Google.Protobuf.3.21.9/lib/net45/Google.Protobuf.dll" />
     <AssemblyLocation assemblyName="ICSharpCode.SharpZipLib" processorArchitecture="MSIL" location="Packages/SharpZipLib.1.4.0/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />

--- a/examples/Torch/NeuralNetsTrainedOnline/.bonsai/Bonsai.config
+++ b/examples/Torch/NeuralNetsTrainedOnline/.bonsai/Bonsai.config
@@ -4,19 +4,19 @@
     <Package id="Bonsai" version="2.9.0" />
     <Package id="Bonsai.Core" version="2.9.0" />
     <Package id="Bonsai.Design" version="2.9.0" />
-    <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.0" />
+    <Package id="Bonsai.Design.Visualizers" version="2.9.0" />
+    <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
-    <Package id="Bonsai.Gui" version="0.1.0" />
+    <Package id="Bonsai.Gui" version="0.2.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Torch" version="0.4.1" />
     <Package id="Bonsai.ML.Torch-cpu" version="0.4.1" />
-    <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
-    <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.System" version="2.8.1" />
-    <Package id="Bonsai.Vision" version="2.8.1" />
-    <Package id="Bonsai.Vision.Design" version="2.8.1" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
+    <Package id="Bonsai.System" version="2.9.0" />
+    <Package id="Bonsai.Vision" version="2.9.0" />
+    <Package id="Bonsai.Vision.Design" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
     <Package id="Google.Protobuf" version="3.21.9" />
@@ -74,18 +74,18 @@
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages/Bonsai.2.9.0/lib/net48/Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages/Bonsai.Core.2.9.0/lib/net472/Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Design.2.9.0/lib/net472/Bonsai.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.8.0/lib/net462/Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.8.0/lib/net462/Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages/Bonsai.Design.Visualizers.2.9.0/lib/net472/Bonsai.Design.Visualizers.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.1.0/lib/net472/Bonsai.Gui.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages/Bonsai.Gui.0.2.0/lib/net472/Bonsai.Gui.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Torch" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Torch.0.4.1/lib/net472/Bonsai.ML.Torch.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.8.0/lib/net462/Bonsai.Scripting.Expressions.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.8.0/lib/net462/Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.8.1/lib/net462/Bonsai.System.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.8.1/lib/net462/Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.8.1/lib/net462/Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.2.9.0/lib/net472/Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Vision.Design.2.9.0/lib/net472/Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Google.Protobuf" processorArchitecture="MSIL" location="Packages/Google.Protobuf.3.21.9/lib/net45/Google.Protobuf.dll" />
     <AssemblyLocation assemblyName="ICSharpCode.SharpZipLib" processorArchitecture="MSIL" location="Packages/SharpZipLib.1.4.0/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />


### PR DESCRIPTION
This PR updates all of the Bonsai package dependency versions in each example Bonsai.config to match the current latest version (2.9.0). This PR also removes redundant Bonsai packages that are no longer necessary for the example workflows to run. Fixes #28.
