### PR TITLE
Update package names and namespaces in example workflows

### DIFF
--- a/examples/HiddenMarkovModels/ExtendedModelConfiguration/.bonsai/Bonsai.config
+++ b/examples/HiddenMarkovModels/ExtendedModelConfiguration/.bonsai/Bonsai.config
@@ -7,7 +7,7 @@
     <Package id="Bonsai.Editor" version="2.9.0" />
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
-    <Package id="Bonsai.ML.HiddenMarkovModels" version="0.4.1" />
+    <Package id="Bonsai.ML.Hmm.Python" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
     <Package id="Bonsai.Scripting.Python" version="0.3.0" />
@@ -41,7 +41,7 @@
     <AssemblyReference assemblyName="Bonsai.Editor" />
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
-    <AssemblyReference assemblyName="Bonsai.ML.HiddenMarkovModels" />
+    <AssemblyReference assemblyName="Bonsai.ML.Hmm.Python" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
@@ -54,7 +54,7 @@
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.HiddenMarkovModels" processorArchitecture="MSIL" location="Packages/Bonsai.ML.HiddenMarkovModels.0.4.1/lib/net472/Bonsai.ML.HiddenMarkovModels.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Hmm.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Hmm.Python.0.4.1/lib/net472/Bonsai.ML.Hmm.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />

--- a/examples/HiddenMarkovModels/ExtendedModelConfiguration/LoadModelConfig.bonsai
+++ b/examples/HiddenMarkovModels/ExtendedModelConfiguration/LoadModelConfig.bonsai
@@ -4,7 +4,7 @@
                  xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
-                 xmlns:p1="clr-namespace:Bonsai.ML.HiddenMarkovModels;assembly=Bonsai.ML.HiddenMarkovModels"
+                 xmlns:p1="clr-namespace:Bonsai.ML.Hmm.Python;assembly=Bonsai.ML.Hmm.Python"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -14,7 +14,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:LoadHMMModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:LoadHMMModule.bonsai" />
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
@@ -49,7 +49,7 @@
           <Property Name="Dimensions" Selector="Dimensions" />
         </PropertyMappings>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:CreateHMM.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:CreateHMM.bonsai">
         <Name>hmm</Name>
         <NumStates>2</NumStates>
         <Dimensions>2</Dimensions>

--- a/examples/HiddenMarkovModels/ExtendedModelConfiguration/SaveModelConfig.bonsai
+++ b/examples/HiddenMarkovModels/ExtendedModelConfiguration/SaveModelConfig.bonsai
@@ -2,9 +2,9 @@
 <WorkflowBuilder Version="2.9.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
-                 xmlns:p1="clr-namespace:Bonsai.ML.HiddenMarkovModels.Observations;assembly=Bonsai.ML.HiddenMarkovModels"
-                 xmlns:p2="clr-namespace:Bonsai.ML.HiddenMarkovModels.Transitions;assembly=Bonsai.ML.HiddenMarkovModels"
-                 xmlns:p3="clr-namespace:Bonsai.ML.HiddenMarkovModels;assembly=Bonsai.ML.HiddenMarkovModels"
+                 xmlns:p1="clr-namespace:Bonsai.ML.Hmm.Python.Observations;assembly=Bonsai.ML.Hmm.Python"
+                 xmlns:p2="clr-namespace:Bonsai.ML.Hmm.Python.Transitions;assembly=Bonsai.ML.Hmm.Python"
+                 xmlns:p3="clr-namespace:Bonsai.ML.Hmm.Python;assembly=Bonsai.ML.Hmm.Python"
                  xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns="https://bonsai-rx.org/2018/workflow">
@@ -16,7 +16,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:LoadHMMModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:LoadHMMModule.bonsai" />
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
@@ -64,7 +64,7 @@
               <Property Name="NumStates" />
               <Property Name="Dimensions" />
             </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:CreateHMM.bonsai">
+            <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:CreateHMM.bonsai">
               <Name>hmm</Name>
               <NumStates>2</NumStates>
               <Dimensions>2</Dimensions>

--- a/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/.bonsai/Bonsai.config
+++ b/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/.bonsai/Bonsai.config
@@ -11,10 +11,10 @@
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.HiddenMarkovModels" version="0.4.1" />
-    <Package id="Bonsai.ML.HiddenMarkovModels.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Hmm.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Hmm.Python.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
     <Package id="Bonsai.Scripting.Python" version="0.3.0" />
@@ -61,10 +61,10 @@
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.HiddenMarkovModels" />
-    <AssemblyReference assemblyName="Bonsai.ML.HiddenMarkovModels.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Hmm.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Hmm.Python.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
@@ -83,10 +83,10 @@
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.HiddenMarkovModels" processorArchitecture="MSIL" location="Packages/Bonsai.ML.HiddenMarkovModels.0.4.1/lib/net472/Bonsai.ML.HiddenMarkovModels.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.HiddenMarkovModels.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.HiddenMarkovModels.Design.0.4.1/lib/net472/Bonsai.ML.HiddenMarkovModels.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Hmm.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Hmm.Python.0.4.1/lib/net472/Bonsai.ML.Hmm.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Hmm.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Hmm.Python.Design.0.4.1/lib/net472/Bonsai.ML.Hmm.Python.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.0.4.1/lib/net472/Bonsai.ML.Lds.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.Design.0.4.1/lib/net472/Bonsai.ML.Lds.Python.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />

--- a/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/InferringBehavioralState.bonsai
+++ b/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/InferringBehavioralState.bonsai
@@ -19,8 +19,8 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:LoadHMMModule.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:LoadHMMModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LoadLDSModule.bonsai" />
       <Expression xsi:type="GroupWorkflow">
         <Name>MouseTracking</Name>
         <Workflow>
@@ -307,7 +307,7 @@
           </Edges>
         </Workflow>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateObservation2D.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateObservation2D.bonsai" />
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Centroid</Name>
       </Expression>
@@ -325,7 +325,7 @@
           <Property Name="Pos_y0" Selector="Y" />
         </PropertyMappings>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateKFModel.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateKFModel.bonsai">
         <Name>KFmodel</Name>
         <Fps>60</Fps>
         <Pos_x0>668.08917236328125</Pos_x0>
@@ -342,7 +342,7 @@
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>KFParameters</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:CreateHMM.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:CreateHMM.bonsai">
         <Name>hmm</Name>
         <NumStates>6</NumStates>
         <Dimensions>2</Dimensions>
@@ -359,7 +359,7 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>Centroid</Name>
             </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.PerformInference.bonsai">
+            <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.PerformInference.bonsai">
               <Name>KFmodel</Name>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -434,7 +434,7 @@
                 <rx:Count>1</rx:Count>
               </Combinator>
             </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:InferState.bonsai">
+            <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:InferState.bonsai">
               <Name>hmm</Name>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -464,7 +464,7 @@
       <Expression xsi:type="SubscribeSubject">
         <Name>HMMObservation</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:RunFitAsync.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:RunFitAsync.bonsai">
         <BatchSize>1000</BatchSize>
         <Name>hmm</Name>
         <NumIterations>50</NumIterations>
@@ -473,7 +473,7 @@
         <TransitionParams>true</TransitionParams>
         <ObservationParams>true</ObservationParams>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:CheckFitFinished.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:CheckFitFinished.bonsai">
         <Name>hmm</Name>
         <TimerFrequency>PT1S</TimerFrequency>
       </Expression>

--- a/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/README.md
+++ b/examples/HiddenMarkovModels/InferringBehavioralStateFromKinematics/README.md
@@ -27,7 +27,7 @@ If you used the bootstrapping method, you don't have to worry about the package 
 * Bonsai - Numerics v0.9.0
 
 > [!WARNING]
-> This example builds on the [LDS Kinematics Foraging Mouse example](../../LinearDynamicalSystems/Kinematics/ForagingMouse/README.md) and requires both the *Bonsai.ML.LinearDynamicalSystems* package and the *Bonsai.ML.HiddenMarkovModels* package. See the installation guide to ensure both packages are installed and working correctly.
+> This example builds on the [LDS Kinematics Foraging Mouse example](../../LinearDynamicalSystems/Kinematics/ForagingMouse/README.md) and requires both the *Bonsai.ML.Lds.Python* package and the *Bonsai.ML.Hmm.Python* package. See the installation guide to ensure both packages are installed and working correctly.
 
 ### Workflow
 

--- a/examples/HiddenMarkovModels/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/HiddenMarkovModels/SimulatedData/.bonsai/Bonsai.config
@@ -12,9 +12,9 @@
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.HiddenMarkovModels" version="0.4.1" />
-    <Package id="Bonsai.ML.HiddenMarkovModels.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
+    <Package id="Bonsai.ML.Hmm.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Hmm.Python.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Numerics" version="0.10.0" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
@@ -63,9 +63,9 @@
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.HiddenMarkovModels" />
-    <AssemblyReference assemblyName="Bonsai.ML.HiddenMarkovModels.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
+    <AssemblyReference assemblyName="Bonsai.ML.Hmm.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Hmm.Python.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Numerics" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
@@ -86,9 +86,9 @@
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.HiddenMarkovModels" processorArchitecture="MSIL" location="Packages/Bonsai.ML.HiddenMarkovModels.0.4.1/lib/net472/Bonsai.ML.HiddenMarkovModels.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.HiddenMarkovModels.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.HiddenMarkovModels.Design.0.4.1/lib/net472/Bonsai.ML.HiddenMarkovModels.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Hmm.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Hmm.Python.0.4.1/lib/net472/Bonsai.ML.Hmm.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Hmm.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Hmm.Python.Design.0.4.1/lib/net472/Bonsai.ML.Hmm.Python.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.0.4.1/lib/net472/Bonsai.ML.Lds.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.10.0/lib/net462/Bonsai.Numerics.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />

--- a/examples/HiddenMarkovModels/SimulatedData/SimulatedData.bonsai
+++ b/examples/HiddenMarkovModels/SimulatedData/SimulatedData.bonsai
@@ -18,11 +18,11 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:LoadHMMModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:LoadHMMModule.bonsai" />
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:CreateHMM.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:CreateHMM.bonsai">
         <Name>hmm</Name>
         <NumStates>2</NumStates>
         <Dimensions>2</Dimensions>
@@ -292,7 +292,7 @@
       <Expression xsi:type="SubscribeSubject">
         <Name>Observation</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:RunFitAsync.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:RunFitAsync.bonsai">
         <BatchSize>80</BatchSize>
         <Name>hmm</Name>
         <NumIterations>50</NumIterations>
@@ -301,7 +301,7 @@
         <TransitionParams>true</TransitionParams>
         <ObservationParams>true</ObservationParams>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:CheckFitFinished.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:CheckFitFinished.bonsai">
         <Name>hmm</Name>
         <TimerFrequency>PT1S</TimerFrequency>
       </Expression>
@@ -317,7 +317,7 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>Observation</Name>
             </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.HiddenMarkovModels:InferState.bonsai">
+            <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Hmm.Python:InferState.bonsai">
               <Name>hmm</Name>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />

--- a/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/.bonsai/Bonsai.config
@@ -11,8 +11,8 @@
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
@@ -65,8 +65,8 @@
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
@@ -88,8 +88,8 @@
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.0.4.1/lib/net472/Bonsai.ML.Lds.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.Design.0.4.1/lib/net472/Bonsai.ML.Lds.Python.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/ForagingMouse.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/ForagingMouse/ForagingMouse.bonsai
@@ -309,11 +309,11 @@
       <Expression xsi:type="SubscribeSubject">
         <Name>RuntimeEngine</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LoadLDSModule.bonsai" />
       <Expression xsi:type="SubscribeSubject">
         <Name>Centroid</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateObservation2D.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateObservation2D.bonsai" />
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Observation</Name>
       </Expression>
@@ -358,7 +358,7 @@
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Fps" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateKFModel.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateKFModel.bonsai">
         <Name>model</Name>
         <Fps>50</Fps>
         <Pos_x0>640.20025634765625</Pos_x0>
@@ -384,7 +384,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:SubscribeWhen" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.PerformInference.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.PerformInference.bonsai">
         <Name>model</Name>
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject">

--- a/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/.bonsai/Bonsai.config
@@ -11,8 +11,8 @@
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
@@ -61,8 +61,8 @@
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
@@ -82,8 +82,8 @@
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.0.4.1/lib/net472/Bonsai.ML.Lds.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.Design.0.4.1/lib/net472/Bonsai.ML.Lds.Python.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/ForecastingForagingMouse.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/ForecastingForagingMouse/ForecastingForagingMouse.bonsai
@@ -307,11 +307,11 @@
       <Expression xsi:type="SubscribeSubject">
         <Name>RuntimeEngine</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LoadLDSModule.bonsai" />
       <Expression xsi:type="SubscribeSubject">
         <Name>Centroid</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateObservation2D.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateObservation2D.bonsai" />
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Observation</Name>
       </Expression>
@@ -356,7 +356,7 @@
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Fps" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateKFModel.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateKFModel.bonsai">
         <Name>model</Name>
         <Fps>50</Fps>
         <Pos_x0>640.20025634765625</Pos_x0>
@@ -382,13 +382,13 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:SubscribeWhen" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.PerformInference.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.PerformInference.bonsai">
         <Name>model</Name>
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>InferredKinematics</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.PerformForecasting.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.PerformForecasting.bonsai">
         <Name>model</Name>
         <Timesteps>30</Timesteps>
       </Expression>

--- a/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/.bonsai/Bonsai.config
@@ -11,8 +11,8 @@
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
@@ -64,8 +64,8 @@
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
@@ -87,8 +87,8 @@
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.0.4.1/lib/net472/Bonsai.ML.Lds.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.Design.0.4.1/lib/net472/Bonsai.ML.Lds.Python.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/ModelOptimizationForagingMouse.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/ModelOptimizationForagingMouse/ModelOptimizationForagingMouse.bonsai
@@ -309,11 +309,11 @@
       <Expression xsi:type="SubscribeSubject">
         <Name>RuntimeEngine</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LoadLDSModule.bonsai" />
       <Expression xsi:type="SubscribeSubject">
         <Name>Centroid</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateObservation2D.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateObservation2D.bonsai" />
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Observation</Name>
       </Expression>
@@ -358,7 +358,7 @@
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Fps" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateKFModel.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateKFModel.bonsai">
         <Name>model</Name>
         <Fps>50</Fps>
         <Pos_x0>640.20025634765625</Pos_x0>
@@ -384,7 +384,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:SubscribeWhen" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Learning.RunOptimizationAsync.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Learning.RunOptimizationAsync.bonsai">
         <BatchSize>200</BatchSize>
         <Name>model</Name>
         <sigma_a>true</sigma_a>
@@ -403,7 +403,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:SubscribeWhen" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.PerformInference.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.PerformInference.bonsai">
         <Name>model</Name>
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject">

--- a/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/SimulatedData/.bonsai/Bonsai.config
@@ -11,8 +11,8 @@
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Numerics" version="0.10.0" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
@@ -66,8 +66,8 @@
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Numerics" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
@@ -90,8 +90,8 @@
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.0.4.1/lib/net472/Bonsai.ML.Lds.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.Design.0.4.1/lib/net472/Bonsai.ML.Lds.Python.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.10.0/lib/net462/Bonsai.Numerics.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/SimulatedData/Simulation.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/SimulatedData/Simulation.bonsai
@@ -33,7 +33,7 @@
       <Expression xsi:type="SubscribeSubject">
         <Name>RuntimeEngine</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LoadLDSModule.bonsai" />
       <Expression xsi:type="SubscribeSubject">
         <Name>Fps</Name>
       </Expression>
@@ -217,7 +217,7 @@
           </Edges>
         </Workflow>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateObservation2D.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateObservation2D.bonsai" />
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Observation</Name>
       </Expression>
@@ -243,7 +243,7 @@
           <Property Name="Fps" />
         </PropertyMappings>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateKFModel.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateKFModel.bonsai">
         <Name>model</Name>
         <Fps>20</Fps>
         <Pos_x0>391.51131518877759</Pos_x0>
@@ -269,7 +269,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:SubscribeWhen" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.PerformInference.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.PerformInference.bonsai">
         <Name>model</Name>
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject">

--- a/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/.bonsai/Bonsai.config
@@ -11,8 +11,8 @@
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.9.0" />
@@ -65,8 +65,8 @@
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
@@ -88,8 +88,8 @@
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.0.4.1/lib/net472/Bonsai.ML.Lds.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.Design.0.4.1/lib/net472/Bonsai.ML.Lds.Python.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.9.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />

--- a/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/ZebrafishTracking.bonsai
+++ b/examples/LinearDynamicalSystems/Kinematics/ZebrafishCentroidTracking/ZebrafishTracking.bonsai
@@ -91,11 +91,11 @@
       <Expression xsi:type="SubscribeSubject">
         <Name>RuntimeEngine</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LoadLDSModule.bonsai" />
       <Expression xsi:type="SubscribeSubject">
         <Name>Centroid</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateObservation2D.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateObservation2D.bonsai" />
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Observation</Name>
       </Expression>
@@ -140,7 +140,7 @@
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Fps" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.CreateKFModel.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.CreateKFModel.bonsai">
         <Name>model</Name>
         <Fps>200</Fps>
         <Pos_x0>86.041664123535156</Pos_x0>
@@ -166,7 +166,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:SubscribeWhen" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:Kinematics.PerformInference.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:Kinematics.PerformInference.bonsai">
         <Name>model</Name>
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject">

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/.bonsai/Bonsai.config
@@ -10,8 +10,8 @@
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Scripting.Python" version="0.3.0" />
     <Package id="Bonsai.System" version="2.9.0" />
@@ -55,8 +55,8 @@
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Python" />
     <AssemblyReference assemblyName="Bonsai.System" />
@@ -73,8 +73,8 @@
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.0.4.1/lib/net472/Bonsai.ML.Lds.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.Design.0.4.1/lib/net472/Bonsai.ML.Lds.Python.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Python" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Python.0.3.0/lib/net472/Bonsai.Scripting.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />

--- a/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/ReceptiveFieldSimpleCell.bonsai
+++ b/examples/LinearDynamicalSystems/LinearRegression/ReceptiveFieldSimpleCell/ReceptiveFieldSimpleCell.bonsai
@@ -4,7 +4,7 @@
                  xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
                  xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
-                 xmlns:p1="clr-namespace:Bonsai.ML.LinearDynamicalSystems;assembly=Bonsai.ML.LinearDynamicalSystems"
+                 xmlns:p1="clr-namespace:Bonsai.ML.Lds.Python;assembly=Bonsai.ML.Lds.Python"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -14,7 +14,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LoadLDSModule.bonsai" />
       <Expression xsi:type="GroupWorkflow">
         <Name>LoadData</Name>
         <Workflow>
@@ -63,7 +63,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.CreateKFModel.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LinearRegression.CreateKFModel.bonsai">
         <LikelihoodPrecisionCoefficient>25</LikelihoodPrecisionCoefficient>
         <PriorPrecisionCoefficient>2</PriorPrecisionCoefficient>
         <NumFeatures>145</NumFeatures>
@@ -81,7 +81,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:SubscribeWhen" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.PerformInference.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LinearRegression.PerformInference.bonsai">
         <Name>model</Name>
       </Expression>
       <Expression xsi:type="GroupWorkflow">

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/.bonsai/Bonsai.config
@@ -10,8 +10,8 @@
     <Package id="Bonsai.ML" version="0.4.1" />
     <Package id="Bonsai.ML.Data" version="0.4.1" />
     <Package id="Bonsai.ML.Design" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems" version="0.4.1" />
-    <Package id="Bonsai.ML.LinearDynamicalSystems.Design" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python" version="0.4.1" />
+    <Package id="Bonsai.ML.Lds.Python.Design" version="0.4.1" />
     <Package id="Bonsai.ML.Python" version="0.4.1" />
     <Package id="Bonsai.Numerics" version="0.10.0" />
     <Package id="Bonsai.Scripting.Expressions" version="2.9.0" />
@@ -59,8 +59,8 @@
     <AssemblyReference assemblyName="Bonsai.ML" />
     <AssemblyReference assemblyName="Bonsai.ML.Data" />
     <AssemblyReference assemblyName="Bonsai.ML.Design" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems" />
-    <AssemblyReference assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python" />
+    <AssemblyReference assemblyName="Bonsai.ML.Lds.Python.Design" />
     <AssemblyReference assemblyName="Bonsai.ML.Python" />
     <AssemblyReference assemblyName="Bonsai.Numerics" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
@@ -80,8 +80,8 @@
     <AssemblyLocation assemblyName="Bonsai.ML" processorArchitecture="MSIL" location="Packages/Bonsai.ML.0.4.1/lib/net472/Bonsai.ML.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Data" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Data.0.4.1/lib/net472/Bonsai.ML.Data.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Design.0.4.1/lib/net472/Bonsai.ML.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.dll" />
-    <AssemblyLocation assemblyName="Bonsai.ML.LinearDynamicalSystems.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.LinearDynamicalSystems.Design.0.4.1/lib/net472/Bonsai.ML.LinearDynamicalSystems.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.0.4.1/lib/net472/Bonsai.ML.Lds.Python.dll" />
+    <AssemblyLocation assemblyName="Bonsai.ML.Lds.Python.Design" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Lds.Python.Design.0.4.1/lib/net472/Bonsai.ML.Lds.Python.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.ML.Python" processorArchitecture="MSIL" location="Packages/Bonsai.ML.Python.0.4.1/lib/net472/Bonsai.ML.Python.dll" />
     <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages/Bonsai.Numerics.0.10.0/lib/net462/Bonsai.Numerics.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.9.0/lib/net472/Bonsai.Scripting.Expressions.dll" />

--- a/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/Simulation.bonsai
+++ b/examples/LinearDynamicalSystems/LinearRegression/SimulatedData/Simulation.bonsai
@@ -15,7 +15,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LoadLDSModule.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LoadLDSModule.bonsai" />
       <Expression xsi:type="GroupWorkflow">
         <Name>SyntheticDataset</Name>
         <Workflow>
@@ -237,7 +237,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="py:GetRuntime" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.CreateKFModel.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LinearRegression.CreateKFModel.bonsai">
         <LikelihoodPrecisionCoefficient>25</LikelihoodPrecisionCoefficient>
         <PriorPrecisionCoefficient>2</PriorPrecisionCoefficient>
         <NumFeatures>2</NumFeatures>
@@ -255,10 +255,10 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:SubscribeWhen" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.PerformInference.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LinearRegression.PerformInference.bonsai">
         <Name>model</Name>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.LinearDynamicalSystems:LinearRegression.CreateMultivariatePDF.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.ML.Lds.Python:LinearRegression.CreateMultivariatePDF.bonsai">
         <Name>model</Name>
         <X0>-1</X0>
         <X1>1</X1>


### PR DESCRIPTION
This PR updates the `HiddenMarkovModels` and `LinearDynamicalSystems` example workflows to use the new naming conventions for the `Bonsai.ML` packages introduced in https://github.com/bonsai-rx/machinelearning/pull/74. The changes replace references to the older `.HiddenMarkovModels` and `.LinearDynamicalSystems` packages with their equivalent `.Hmm.Python` and `.Lds.Python` package names throughout configuration and workflow files.